### PR TITLE
[French] Improve couple skill translations and UI terms

### DIFF
--- a/French/Skills.csv
+++ b/French/Skills.csv
@@ -471,12 +471,12 @@ PROPSKILL_TXT_100122,Bleeding (From Weapon),Saignement (Arme)
 PROPSKILL_TXT_100123,Increases FP and MP Restoration by 10% for you and your partner for 10 minutes.,Récupération de FP et MP augmentée de 10 % pendant 10 minutes.
 PROPSKILL_TXT_100124,Madrigal Stroll,Balade à Madrigal
 PROPSKILL_TXT_100125,Increases movement speed by 5% for you and your partner for 10 minutes.,Vitesse de déplacement augmentée de 5 % pendant 10 minutes.
-PROPSKILL_TXT_100126,Field Outing,Sortie sur le terrain
+PROPSKILL_TXT_100126,Field Outing,Escapade en duo
 PROPSKILL_TXT_100127,Reload the Experience Lock Gauge by 5% of the maximum.,Réinitialise la jauge de verrouillage d'expérience de 5 % de son maximum.
 PROPSKILL_TXT_100128,Party Together,Ensemble en groupe
-PROPSKILL_TXT_100129,Increases party experience by 10% for 30 minutes while you and your partner are in the same party.,Expérience de groupe augmentée de 10 % pendant 30 minutes. Ne fonctionne que si les deux membres sont dans le même groupe.
+PROPSKILL_TXT_100129,Increases party experience by 10% for 30 minutes while you and your partner are in the same party.,Bonus d'expérience de groupe de 10 % pendant 30 minutes si vous et votre partenaire êtes réunis dans le même groupe.
 PROPSKILL_TXT_100130,Golden Luck,Chance dorée
-PROPSKILL_TXT_100131,Increases drop rate and Penya gained by 5% for you and your partner for 10 minutes.,Quantité de drops et de Penya augmentée de 5 % pendant 10 minutes.
+PROPSKILL_TXT_100131,Increases drop rate and Penya gained by 5% for you and your partner for 10 minutes.,Bonus de 5 % sur les drops et les Penya obtenus pour vous et votre partenaire pendant 10 minutes.
 PROPSKILL_TXT_100132,Stamina Boost,Boost de stamina
 PROPSKILL_TXT_100133,Increases all stats by 5 for you and your partner for 10 minutes.,Toutes les statistiques augmentés de 5 pendant 10 minutes.
 PROPSKILL_TXT_100134,Sky's Blessing,Bénédiction du ciel

--- a/French/UI.csv
+++ b/French/UI.csv
@@ -2185,7 +2185,7 @@ UI_GUILDHOUSING_ARTIFACTBATTLEJOIN_MSGBOX_INFO,"Would you like to join the next 
 UI_GUILDHOUSING_ARTIFACTBATTLECANCEL_MSGBOX_INFO,Would you like to cancel joining the Guild Artifact Battle? You will receive all of the penyas you've used to join the battle.,Souhaitez-vous vous désinscrire de la prochaine Guerre des Artefacts ? Vous récupérerez tous les Penyas utilisés lors de votre inscription.
 UI_GUILD_TAB_HOUSING_NEXTARTIFACTBATTLEHDR,Next artifact battle in:,Prochaine Guerre des Artefacts dans :
 UI_CHARINFO_HOUSING,Housing,Maison
-UI_CHARINFO_HOUSING_TEMPLATE,Current Template,Current Template
+UI_CHARINFO_HOUSING_TEMPLATE,Current Template,Modèle actuel
 UI_CHARINFO_HOUSING_EXPIRATION,Expires in,Expire dans
 UI_CHARINFO_HOUSING_BONUSES,Current bonuses,Bonus actuels
 UI_CHARINFO_HOUSING_NOHOUSE,No house yet.,Pas encore de maison
@@ -2523,7 +2523,7 @@ UI_COUPLE_BREAKUP_FORCE,Break Up(F),Rupture(F)
 UI_COUPLE_TELEPORT,Teleport,Téléportation
 UI_COUPLE_TELEPORT_TEXT,Teleport to your partner's location? Teleportation is not possible if your partner is in an inaccessible area.,Téléporter à l’emplacement de votre partenaire ? Impossible si votre partenaire est dans une zone inaccessible
 UI_COUPLE_CHEER,Cheer,Encourager
-UI_COUPLE_FORM_DATE,Formation Date,Date de formation
+UI_COUPLE_FORM_DATE,Formation Date,Date d'union
 UI_COUPLE_STORAGE_AVAIL,Available Storage Slots,Emplacements disponibles
 UI_COUPLE_MAX_TELEPORTS,Maximum Daily Teleports,Téléportations max par jour
 UI_COUPLE_MAX_CHEERS,Maximum Daily Cheers,Encouragements max par jour


### PR DESCRIPTION
### Description
Amélioration de plusieurs traductions françaises liées au système de couple et à l'interface :
- `UI_CHARINFO_HOUSING_TEMPLATE` : "Current Template" → "Modèle actuel" (non traduit)
- `UI_COUPLE_FORM_DATE` : "Date de formation" → "Date d'union"
- `PROPSKILL_TXT_100126` (Field Outing) : "Sortie sur le terrain" → "Escapade en duo"
- `PROPSKILL_TXT_100129` (Party Together) : reformulation plus naturelle, ajout de la condition partenaire/groupe manquante
- `PROPSKILL_TXT_100131` (Golden Luck) : correction de la faute "Peyna" → "Penya", ajout de la mention du partenaire manquante

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project