### PR TITLE
[Filipino] Item changes

### DIFF
--- a/Filipino/Items.csv
+++ b/Filipino/Items.csv
@@ -1981,48 +1981,48 @@ PROPITEM_TXT_003960,Legendary Golden Staff,Alamat na Gintong Staff
 PROPITEM_TXT_003962,Legendary Golden Bow,Alamat na Gintong Pana
 PROPITEM_TXT_003964,Legendary Golden Yo-Yo,Alamat na Gintong Yo-yo
 PROPITEM_TXT_003966,First Refresher,First Refresher
-PROPITEM_TXT_003967,MP 65 Recovery,MP 65 Recovery
+PROPITEM_TXT_003967,MP 65 Recovery,Ibinabalik ang 65 MP
 PROPITEM_TXT_003968,Second Refresher,Second Refresher
-PROPITEM_TXT_003969,MP 125 Recovery,MP 125 Recovery
+PROPITEM_TXT_003969,MP 125 Recovery,Ibinabalik ang 125 MP
 PROPITEM_TXT_003970,Third Refresher,Third Refresher
-PROPITEM_TXT_003971,MP 185 Recovery,MP 185 Recovery
+PROPITEM_TXT_003971,MP 185 Recovery,Ibinabalik ang 185 MP
 PROPITEM_TXT_003972,Fourth Refresher,Fourth Refresher
-PROPITEM_TXT_003973,MP 245 Recovery,MP 245 Recovery
+PROPITEM_TXT_003973,MP 245 Recovery,Ibinabalik ang 245 MP
 PROPITEM_TXT_003974,Fifth Refresher,Fifth Refresher
-PROPITEM_TXT_003975,MP 315 Recovery,MP 315 Recovery
+PROPITEM_TXT_003975,MP 315 Recovery,Ibinabalik ang 315 MP
 PROPITEM_TXT_003976,Sixth Refresher,Sixth Refresher
-PROPITEM_TXT_003977,MP 375 Recovery,MP 375 Recovery
+PROPITEM_TXT_003977,MP 375 Recovery,Ibinabalik ang 375 MP
 PROPITEM_TXT_003978,Seventh Refresher,Seventh Refresher
-PROPITEM_TXT_003979,MP 450 Recovery,MP 450 Recovery
+PROPITEM_TXT_003979,MP 450 Recovery,Ibinabalik ang 450 MP
 PROPITEM_TXT_003980,Eighth Refresher,Eighth Refresher
-PROPITEM_TXT_003981,MP 525 Recovery,MP 525 Recovery
+PROPITEM_TXT_003981,MP 525 Recovery,Ibinabalik ang 525 MP
 PROPITEM_TXT_003982,Ninth Refresher,Ninth Refresher
-PROPITEM_TXT_003983,MP 600 Recovery,MP 600 Recovery
+PROPITEM_TXT_003983,MP 600 Recovery,Ibinabalik ang 600 MP
 PROPITEM_TXT_003984,Tenth Refresher,Tenth Refresher
-PROPITEM_TXT_003985,MP 675 Recovery,MP 675 Recovery
+PROPITEM_TXT_003985,MP 675 Recovery,Ibinabalik ang 675 MP
 PROPITEM_TXT_003986,Antidote Potion,Antidote Potion
 PROPITEM_TXT_003987,A poison antidote. This vial will instantly cure poison effects when consumed.,A poison antidote. This vial will instantly cure poison effects when consumed.
 PROPITEM_TXT_003988,Cure Disease Potion,Cure Disease Potion
 PROPITEM_TXT_003990,Water Bottle,Water Bottle
 PROPITEM_TXT_003992,Oil Bottle,Oil Bottle
 PROPITEM_TXT_003994,VitalDrink 100,VitalDrink 100
-PROPITEM_TXT_003995,FP 60 Recovery,FP 60 Recovery
+PROPITEM_TXT_003995,FP 60 Recovery,Ibinabalik ang 60 FP
 PROPITEM_TXT_003996,VitalDrink 200,VitalDrink 200
-PROPITEM_TXT_003997,FP 120 Recovery,FP 120 Recovery
+PROPITEM_TXT_003997,FP 120 Recovery,Ibinabalik ang 120 FP
 PROPITEM_TXT_003998,VitalDrink 300,VitalDrink 300
-PROPITEM_TXT_003999,FP 180 Recovery,FP 180 Recovery
+PROPITEM_TXT_003999,FP 180 Recovery,Ibinabalik ang 180 FP
 PROPITEM_TXT_004000,VitalDrink 400,VitalDrink 400
-PROPITEM_TXT_004001,FP 240 Recovery,FP 240 Recovery
+PROPITEM_TXT_004001,FP 240 Recovery,Ibinabalik ang 240 FP
 PROPITEM_TXT_004002,VitalDrink 500,VitalDrink 500
-PROPITEM_TXT_004003,FP 300 Recovery,FP 300 Recovery
+PROPITEM_TXT_004003,FP 300 Recovery,Ibinabalik ang 300 FP
 PROPITEM_TXT_004004,VitalDrink 600,VitalDrink 600
-PROPITEM_TXT_004005,FP 368 Recovery,FP 368 Recovery
+PROPITEM_TXT_004005,FP 368 Recovery,Ibinabalik ang 368 FP
 PROPITEM_TXT_004006,VitalDrink 700,VitalDrink 700
-PROPITEM_TXT_004007,FP 450 Recovery,FP 450 Recovery
+PROPITEM_TXT_004007,FP 450 Recovery,Ibinabalik ang 450 FP
 PROPITEM_TXT_004008,VitalDrink 800,VitalDrink 800
-PROPITEM_TXT_004009,FP 520 Recovery,FP 520 Recovery
+PROPITEM_TXT_004009,FP 520 Recovery,Ibinabalik ang 520 FP
 PROPITEM_TXT_004010,VitalDrink 900,VitalDrink 900
-PROPITEM_TXT_004011,FP 590 Recovery,FP 590 Recovery
+PROPITEM_TXT_004011,FP 590 Recovery,Ibinabalik ang 590 FP
 PROPITEM_TXT_004012,Poison Immunity Potion,Poison Immunity Potion
 PROPITEM_TXT_004013,Short Immunity from Potion,Short Immunity from Potion
 PROPITEM_TXT_004014,Demol Earring +1,Demol Earring +1
@@ -2195,80 +2195,80 @@ PROPITEM_TXT_004190,P.K STA Penalty,P.K STA Penalty
 PROPITEM_TXT_004192,P.K INT Penalty,P.K INT Penalty
 PROPITEM_TXT_004194,P.K DEX Penalty,P.K DEX Penalty
 PROPITEM_TXT_004198,Lollipop,Lollipop
-PROPITEM_TXT_004199,Recovers 70 HP,Recovers 70 HP
+PROPITEM_TXT_004199,Recovers 70 HP,Ibinabalik ang 70 HP
 PROPITEM_TXT_004200,Biscuit,Biscuit
-PROPITEM_TXT_004201,Recovers 140 HP,Recovers 140 HP
-PROPITEM_TXT_004202,Chocolate Bar,Chocolate Bar
-PROPITEM_TXT_004203,Recovers 200 HP,Recovers 200 HP
-PROPITEM_TXT_004204,Milk,Milk
-PROPITEM_TXT_004205,Recovers 260 HP,Recovers 260 HP
+PROPITEM_TXT_004201,Recovers 140 HP,Ibinabalik ang 140 HP
+PROPITEM_TXT_004202,Chocolate Bar,Tsokolate bar
+PROPITEM_TXT_004203,Recovers 200 HP,Ibinabalik ang 200 HP
+PROPITEM_TXT_004204,Milk,Gatas
+PROPITEM_TXT_004205,Recovers 260 HP,Ibinabalik ang 260 HP
 PROPITEM_TXT_004206,Roll Bread,Roll Bread
-PROPITEM_TXT_004207,Recovers 330 HP,Recovers 330 HP
+PROPITEM_TXT_004207,Recovers 330 HP,Ibinabalik ang 330 HP
 PROPITEM_TXT_004208,Hot Dog,Hot Dog
-PROPITEM_TXT_004209,Recovers 429 HP,Recovers 429 HP
+PROPITEM_TXT_004209,Recovers 429 HP,Ibinabalik ang 429 HP
 PROPITEM_TXT_004210,Super Hot Dog,Super Hot Dog
-PROPITEM_TXT_004211,Recovers ALL HP,Recovers ALL HP
+PROPITEM_TXT_004211,Recovers ALL HP,Ibinabalik ang LAHAT ng HP
 PROPITEM_TXT_004212,Pizza,Pizza
-PROPITEM_TXT_004213,Recovers 584 HP,Recovers 584 HP
+PROPITEM_TXT_004213,Recovers 584 HP,Ibinabalik ang 584 HP
 PROPITEM_TXT_004214,Kimbap,Kimbap
-PROPITEM_TXT_004215,Recovers 724 HP,Recovers 724 HP
+PROPITEM_TXT_004215,Recovers 724 HP,Ibinabalik ang 724 HP
 PROPITEM_TXT_004216,Chicken Stick,Chicken Stick
-PROPITEM_TXT_004217,Recover 970 HP,Recover 970 HP
+PROPITEM_TXT_004217,Recover 970 HP,Ibinabalik ang 970 HP
 PROPITEM_TXT_004218,Star Candy,Star Candy
-PROPITEM_TXT_004219,Recover 1200 HP,Recover 1200 HP
+PROPITEM_TXT_004219,Recover 1200 HP,Ibinabalik ang 1200 HP
 PROPITEM_TXT_004220,Meat Skewer,Meat Skewer
-PROPITEM_TXT_004221,Recovers 120 HP,Recovers 120 HP
+PROPITEM_TXT_004221,Recovers 120 HP,Ibinabalik ang 120 HP
 PROPITEM_TXT_004222,Barbecue,Barbecue
-PROPITEM_TXT_004223,Recovers 160 HP,Recovers 160 HP
+PROPITEM_TXT_004223,Recovers 160 HP,Ibinabalik ang 160 HP
 PROPITEM_TXT_004224,Seafood Pancake,Seafood Pancake
-PROPITEM_TXT_004225,Recovers 230 HP,Recovers 230 HP
+PROPITEM_TXT_004225,Recovers 230 HP,Ibinabalik ang 230 HP
 PROPITEM_TXT_004226,Fish Soup,Fish Soup
-PROPITEM_TXT_004227,Recovers 300 HP,Recovers 300 HP
+PROPITEM_TXT_004227,Recovers 300 HP,Ibinabalik ang 300 HP
 PROPITEM_TXT_004228,Sausage Casserole,Sausage Casserole
-PROPITEM_TXT_004229,Recovers 370 HP,Recovers 370 HP
+PROPITEM_TXT_004229,Recovers 370 HP,Ibinabalik ang 370 HP
 PROPITEM_TXT_004230,Fish Stew,Fish Stew
-PROPITEM_TXT_004231,Recovers 514 HP,Recovers 514 HP
+PROPITEM_TXT_004231,Recovers 514 HP,Ibinabalik ang 514 HP
 PROPITEM_TXT_004232,Steamed Seafood,Steamed Seafood
-PROPITEM_TXT_004233,Recovers 670 HP,Recovers 670 HP
+PROPITEM_TXT_004233,Recovers 670 HP,Ibinabalik ang 670 HP
 PROPITEM_TXT_004234,Meat Salad,Meat Salad
-PROPITEM_TXT_004235,Recovers 1300 HP,Recovers 1300 HP
+PROPITEM_TXT_004235,Recovers 1300 HP,Ibinabalik ang 1300 HP
 PROPITEM_TXT_004236,Gratin,Gratin
-PROPITEM_TXT_004237,Recovers 1750 HP,Recovers 1750 HP
+PROPITEM_TXT_004237,Recovers 1750 HP,Ibinabalik ang 1750 HP
 PROPITEM_TXT_004238,Seafood Pizza,Seafood Pizza
-PROPITEM_TXT_004239,Recovers 1450 HP,Recovers 1450 HP
+PROPITEM_TXT_004239,Recovers 1450 HP,Ibinabalik ang 1450 HP
 PROPITEM_TXT_004240,Orange Juice,Orange Juice
-PROPITEM_TXT_004241,Recovers 60 HP,Recovers 60 HP
+PROPITEM_TXT_004241,Recovers 60 HP,Ibinabalik ang 60 HP
 PROPITEM_TXT_004242,Strawberry Shake,Strawberry Shake
-PROPITEM_TXT_004243,Recovers 110 HP,Recovers 110 HP
+PROPITEM_TXT_004243,Recovers 110 HP,Ibinabalik ang 110 HP
 PROPITEM_TXT_004244,Pineapple Cone,Pineapple Cone
 PROPITEM_TXT_004246,Banana Juju Bar,Banana Juju Bar
-PROPITEM_TXT_004247,Recovers 210 HP,Recovers 210 HP
+PROPITEM_TXT_004247,Recovers 210 HP,Ibinabalik ang 210 HP
 PROPITEM_TXT_004248,Fruit Juice,Fruit Juice
 PROPITEM_TXT_004250,Fruit Ice Water,Fruit Ice Water
-PROPITEM_TXT_004251,Recovers 334 HP,Recovers 334 HP
+PROPITEM_TXT_004251,Recovers 334 HP,Ibinabalik ang 334 HP
 PROPITEM_TXT_004252,Fruit Parfait,Fruit Parfait
-PROPITEM_TXT_004253,Recovers 452 HP,Recovers 452 HP
+PROPITEM_TXT_004253,Recovers 452 HP,Ibinabalik ang 452 HP
 PROPITEM_TXT_004254,Fruit Sherbet,Fruit Sherbet
 PROPITEM_TXT_004256,Ice Cream Cake,Ice Cream Cake
-PROPITEM_TXT_004257,Recovers 1170 HP,Recovers 1170 HP
+PROPITEM_TXT_004257,Recovers 1170 HP,Ibinabalik ang 1170 HP
 PROPITEM_TXT_004258,Fruit Punch,Fruit Punch
-PROPITEM_TXT_004259,Recovers 1500 HP,Recovers 1500 HP
+PROPITEM_TXT_004259,Recovers 1500 HP,Ibinabalik ang 1500 HP
 PROPITEM_TXT_004260,Gray Pill,Gray Pill
-PROPITEM_TXT_004261,Recovers 1200 HP,Recovers 1200 HP
+PROPITEM_TXT_004261,Recovers 1200 HP,Ibinabalik ang 1200 HP
 PROPITEM_TXT_004262,Yellow Pill,Yellow Pill
-PROPITEM_TXT_004263,Recover 2000 HP,Recover 2000 HP
+PROPITEM_TXT_004263,Recover 2000 HP,Ibinabalik ang 2000 HP
 PROPITEM_TXT_004264,Blue Pill,Blue Pill
-PROPITEM_TXT_004265,Recovers 4000 HP,Recovers 4000 HP
+PROPITEM_TXT_004265,Recovers 4000 HP,Ibinabalik ang 4000 HP
 PROPITEM_TXT_004266,Red Pill,Red Pill
-PROPITEM_TXT_004267,Recovers 8000 HP,Recovers 8000 HP
+PROPITEM_TXT_004267,Recovers 8000 HP,Ibinabalik ang 8000 HP
 PROPITEM_TXT_004268,Gold Pill,Gold Pill
-PROPITEM_TXT_004269,Recovers 15000 HP,Recovers 15000 HP
+PROPITEM_TXT_004269,Recovers 15000 HP,Ibinabalik ang 15000 HP
 PROPITEM_TXT_004270,Hot Ddukguk,Hot Ddukguk
-PROPITEM_TXT_004271,Recovers 9999 HP,Recovers 9999 HP
+PROPITEM_TXT_004271,Recovers 9999 HP,Ibinabalik ang 9999 HP
 PROPITEM_TXT_004272,Fresh Ddukguk,Fresh Ddukguk
-PROPITEM_TXT_004273,Recovers 9999 FP,Recovers 9999 FP
+PROPITEM_TXT_004273,Recovers 9999 FP,Ibinabalik ang 9999 FP
 PROPITEM_TXT_004274,Sweet Ddukguk,Sweet Ddukguk
-PROPITEM_TXT_004275,Recovers 9999 MP,Recovers 9999 MP
+PROPITEM_TXT_004275,Recovers 9999 MP,Ibinabalik ang 9999 MP
 PROPITEM_TXT_004276,Mineral,Mineral
 PROPITEM_TXT_004278,Erons,Erons
 PROPITEM_TXT_004280,Krasec,Krasec
@@ -4106,9 +4106,9 @@ PROPITEM_TXT_007529,Bloody Staff,Bloody Staff
 PROPITEM_TXT_007531,Bloody Bow,Bloody Bow
 PROPITEM_TXT_007533,Bloody Yo-Yo,Bloody Yo-Yo
 PROPITEM_TXT_007535,Secret Medicine 1,Secret Medicine 1
-PROPITEM_TXT_007536,Recovers 1000 HP,Recovers 1000 HP
+PROPITEM_TXT_007536,Recovers 1000 HP,Ibinabalik ang 1000 HP
 PROPITEM_TXT_007537,Secret Medicine 2,Secret Medicine 2
-PROPITEM_TXT_007538,Recovers 1000 MP,Recovers 1000 MP
+PROPITEM_TXT_007538,Recovers 1000 MP,Ibinabalik ang 1000 MP
 PROPITEM_TXT_007540,Polar Bear,Polar Bear
 PROPITEM_TXT_007541,A Polar Bear that follows its master around and picks up dropped items,A Polar Bear that follows its master around and picks up dropped items
 PROPITEM_TXT_007544,Rice Cake,Rice Cake
@@ -12670,7 +12670,7 @@ PROPITEM_TXT_722024,Wooden Housing Pack,Wooden Housing Pack
 PROPITEM_TXT_722025,Oversized Heart,Oversized Heart
 PROPITEM_TXT_722026,The heart of the great Beast King Khan.,The heart of the great Beast King Khan.
 PROPITEM_TXT_722027,Coral Island Curry,Coral Island Curry
-PROPITEM_TXT_722028,Recovers 2000 HP,Recovers 2000 HP
+PROPITEM_TXT_722028,Recovers 2000 HP,Ibinabalik ang 2000 HP
 PROPITEM_TXT_722035,FWC Remnant,FWC Remnant
 PROPITEM_TXT_722036,An artifact discovered amidst the dismantling of jewelry from an extraordinary event. Dormant powers within may one day be rekindled.,An artifact discovered amidst the dismantling of jewelry from an extraordinary event. Dormant powers within may one day be rekindled.
 PROPITEM_TXT_722037,Trophy of the Master Jeweler,Trophy of the Master Jeweler
@@ -17789,11 +17789,11 @@ PROPITEM_TXT_133408,Fish Sauce (D),Fish Sauce (D)
 PROPITEM_TXT_133409,Fish Sauce (C),Fish Sauce (C)
 PROPITEM_TXT_133410,Sauce made from fish. You can use it in various dishes.,Sauce made from fish. You can use it in various dishes.
 PROPITEM_TXT_133411,Lollipop (C),Lollipop (C)
-PROPITEM_TXT_133412,Recovers 84 HP,Recovers 84 HP
+PROPITEM_TXT_133412,Recovers 84 HP,Ibinabalik ang 84 HP
 PROPITEM_TXT_133413,Meat Skewer (C),Meat Skewer (C)
-PROPITEM_TXT_133414,Recovers 144 HP,Recovers 144 HP
+PROPITEM_TXT_133414,Recovers 144 HP,Ibinabalik ang 144 HP
 PROPITEM_TXT_133415,Biscuit (C),Biscuit (C)
-PROPITEM_TXT_133416,Recovers 144 HP,Recovers 144 HP
+PROPITEM_TXT_133416,Recovers 144 HP,Ibinabalik ang 144 HP
 PROPITEM_TXT_133417,Fish Ball (D),Fish Ball (D)
 PROPITEM_TXT_133418,A dish made by making minced fish meat into balls.,A dish made by making minced fish meat into balls.
 PROPITEM_TXT_133419,Fish Ball (C),Fish Ball (C)
@@ -17803,37 +17803,37 @@ PROPITEM_TXT_133422,Fish Ball (A),Fish Ball (A)
 PROPITEM_TXT_133423,Fish Ball (A+),Fish Ball (A+)
 PROPITEM_TXT_133424,A dish made by making minced fish meat into balls.,A dish made by making minced fish meat into balls.
 PROPITEM_TXT_133425,Seafood Pancake (C),Seafood Pancake (C)
-PROPITEM_TXT_133426,Recovers 276 HP,Recovers 276 HP
+PROPITEM_TXT_133426,Recovers 276 HP,Ibinabalik ang 276 HP
 PROPITEM_TXT_133427,Seafood Pancake (B),Seafood Pancake (B)
 PROPITEM_TXT_133428,Seafood Pancake (A),Seafood Pancake (A)
 PROPITEM_TXT_133429,Seafood Pancake (A+),Seafood Pancake (A+)
-PROPITEM_TXT_133430,Recovers 299 HP,Recovers 299 HP
+PROPITEM_TXT_133430,Recovers 299 HP,Ibinabalik ang 299 HP
 PROPITEM_TXT_133431,Fish Soup (C),Fish Soup (C)
-PROPITEM_TXT_133432,Recovers 360 HP,Recovers 360 HP
+PROPITEM_TXT_133432,Recovers 360 HP,Ibinabalik ang 360 HP
 PROPITEM_TXT_133433,Fish Soup (B),Fish Soup (B)
 PROPITEM_TXT_133434,Fish Soup (A),Fish Soup (A)
 PROPITEM_TXT_133435,Fish Soup (A+),Fish Soup (A+)
-PROPITEM_TXT_133436,Recovers 390 HP,Recovers 390 HP
+PROPITEM_TXT_133436,Recovers 390 HP,Ibinabalik ang 390 HP
 PROPITEM_TXT_133437,Roll Bread (C),Roll Bread (C)
-PROPITEM_TXT_133438,Recovers 396 HP,Recovers 396 HP
+PROPITEM_TXT_133438,Recovers 396 HP,Ibinabalik ang 396 HP
 PROPITEM_TXT_133439,Sausage Casserole (C),Sausage Casserole (C)
-PROPITEM_TXT_133440,Recovers 444 HP,Recovers 444 HP
+PROPITEM_TXT_133440,Recovers 444 HP,Ibinabalik ang 444 HP
 PROPITEM_TXT_133441,Hot Dog (C),Hot Dog (C)
-PROPITEM_TXT_133442,Recovers 515 HP,Recovers 515 HP
+PROPITEM_TXT_133442,Recovers 515 HP,Ibinabalik ang 515 HP
 PROPITEM_TXT_133443,Fish Stew (C),Fish Stew (C)
-PROPITEM_TXT_133444,Recovers 617 HP,Recovers 617 HP
+PROPITEM_TXT_133444,Recovers 617 HP,Ibinabalik ang 617 HP
 PROPITEM_TXT_133445,Fish Stew (B),Fish Stew (B)
 PROPITEM_TXT_133446,Fish Stew (A),Fish Stew (A)
 PROPITEM_TXT_133447,Fish Stew (A+),Fish Stew (A+)
-PROPITEM_TXT_133448,Recovers 668 HP,Recovers 668 HP
+PROPITEM_TXT_133448,Recovers 668 HP,Ibinabalik ang 668 HP
 PROPITEM_TXT_133449,Pizza (C),Pizza (C)
-PROPITEM_TXT_133450,Recovers 701 HP,Recovers 701 HP
+PROPITEM_TXT_133450,Recovers 701 HP,Ibinabalik ang 701 HP
 PROPITEM_TXT_133451,Steamed Seafood (C),Steamed Seafood (C)
-PROPITEM_TXT_133452,Recovers 804 HP,Recovers 804 HP
+PROPITEM_TXT_133452,Recovers 804 HP,Ibinabalik ang 804 HP
 PROPITEM_TXT_134671,Steamed Seafood (B),Steamed Seafood (B)
 PROPITEM_TXT_133453,Steamed Seafood (A),Steamed Seafood (A)
 PROPITEM_TXT_133454,Steamed Seafood (A+),Steamed Seafood (A+)
-PROPITEM_TXT_133455,Recovers 871 HP,Recovers 871 HP
+PROPITEM_TXT_133455,Recovers 871 HP,Ibinabalik ang 871 HP
 PROPITEM_TXT_133456,Grilled Mackerel (D),Grilled Mackerel (D)
 PROPITEM_TXT_133457,A nicely grilled mackerel.,A nicely grilled mackerel.
 PROPITEM_TXT_133458,Grilled Mackerel (C),Grilled Mackerel (C)
@@ -17843,7 +17843,7 @@ PROPITEM_TXT_133461,Grilled Mackerel (A),Grilled Mackerel (A)
 PROPITEM_TXT_133462,Grilled Mackerel (A+),Grilled Mackerel (A+)
 PROPITEM_TXT_133463,A nicely grilled mackerel.,A nicely grilled mackerel.
 PROPITEM_TXT_133464,Chicken Stick (C),Chicken Stick (C)
-PROPITEM_TXT_133465,Recovers 1164 HP,Recovers 1164 HP
+PROPITEM_TXT_133465,Recovers 1164 HP,Ibinabalik ang 1164 HP
 PROPITEM_TXT_133466,Fried Squid (D),Fried Squid (D)
 PROPITEM_TXT_133467,A dish made from fried squid.,A dish made from fried squid.
 PROPITEM_TXT_133468,Fried Squid (C),Fried Squid (C)
@@ -17853,7 +17853,7 @@ PROPITEM_TXT_133471,Fried Squid (A),Fried Squid (A)
 PROPITEM_TXT_133472,Fried Squid (A+),Fried Squid (A+)
 PROPITEM_TXT_133473,A dish made from fried squid.,A dish made from fried squid.
 PROPITEM_TXT_133474,Star Candy (C),Star Candy (C)
-PROPITEM_TXT_133475,Recovers 1440 HP,Recovers 1440 HP
+PROPITEM_TXT_133475,Recovers 1440 HP,Ibinabalik ang 1440 HP
 PROPITEM_TXT_133476,Fish Cutlet (D),Fish Cutlet (D)
 PROPITEM_TXT_133477,A dish made by frying minced fish meat.,A dish made by frying minced fish meat.
 PROPITEM_TXT_133478,Fish Cutlet (C),Fish Cutlet (C)
@@ -17863,13 +17863,13 @@ PROPITEM_TXT_133481,Fish Cutlet (A),Fish Cutlet (A)
 PROPITEM_TXT_133482,Fish Cutlet (A+),Fish Cutlet (A+)
 PROPITEM_TXT_133483,A dish made by frying minced fish meat.,A dish made by frying minced fish meat.
 PROPITEM_TXT_133484,Meat Salad (C),Meat Salad (C)
-PROPITEM_TXT_133485,Recovers 1560 HP,Recovers 1560 HP
+PROPITEM_TXT_133485,Recovers 1560 HP,Ibinabalik ang 1560 HP
 PROPITEM_TXT_133486,Seafood Pizza (C),Seafood Pizza (C)
-PROPITEM_TXT_133487,Recovers 1740 HP,Recovers 1740 HP
+PROPITEM_TXT_133487,Recovers 1740 HP,Ibinabalik ang 1740 HP
 PROPITEM_TXT_133488,Seafood Pizza (B),Seafood Pizza (B)
 PROPITEM_TXT_133489,Seafood Pizza (A),Seafood Pizza (A)
 PROPITEM_TXT_133490,Seafood Pizza (A+),Seafood Pizza (A+)
-PROPITEM_TXT_133491,Recovers 1885 HP,Recovers 1885 HP
+PROPITEM_TXT_133491,Recovers 1885 HP,Ibinabalik ang 1885 HP
 PROPITEM_TXT_133492,Fried Shrimp (D),Fried Shrimp (D)
 PROPITEM_TXT_133493,A dish made from fried shrimp.,A dish made from fried shrimp.
 PROPITEM_TXT_133494,Fried Shrimp (C),Fried Shrimp (C)
@@ -17887,13 +17887,13 @@ PROPITEM_TXT_133505,Shrimp Fried Rice (A),Shrimp Fried Rice (A)
 PROPITEM_TXT_133506,Shrimp Fried Rice (A+),Shrimp Fried Rice (A+)
 PROPITEM_TXT_133507,Fried rice with shrimp inside.,Fried rice with shrimp inside.
 PROPITEM_TXT_133508,Gratin (C),Gratin (C)
-PROPITEM_TXT_133509,Recovers 2100 HP,Recovers 2100 HP
+PROPITEM_TXT_133509,Recovers 2100 HP,Ibinabalik ang 2100 HP
 PROPITEM_TXT_133510,Coral Island Curry (C),Coral Island Curry (C)
-PROPITEM_TXT_133511,Recovers 2400 HP,Recovers 2400 HP
+PROPITEM_TXT_133511,Recovers 2400 HP,Ibinabalik ang 2400 HP
 PROPITEM_TXT_133512,Coral Island Curry (B),Coral Island Curry (B)
 PROPITEM_TXT_133513,Coral Island Curry (A),Coral Island Curry (A)
 PROPITEM_TXT_133514,Coral Island Curry (A+),Coral Island Curry (A+)
-PROPITEM_TXT_133515,Recovers 2600 HP,Recovers 2600 HP
+PROPITEM_TXT_133515,Recovers 2600 HP,Ibinabalik ang 2600 HP
 PROPITEM_TXT_133516,Tuna Sushi (D),Tuna Sushi (D)
 PROPITEM_TXT_133517,Sushi made with tuna on top.,Sushi made with tuna on top.
 PROPITEM_TXT_133518,Tuna Sushi (C),Tuna Sushi (C)
@@ -18023,135 +18023,135 @@ PROPITEM_TXT_133641,Pine Oil (B),Pine Oil (B)
 PROPITEM_TXT_133642,Pine Oil (A),Pine Oil (A)
 PROPITEM_TXT_133643,This oil is harvested from pine trees. It has many uses.,This oil is harvested from pine trees. It has many uses.
 PROPITEM_TXT_133644,VitalDrink 100 (C),VitalDrink 100 (C)
-PROPITEM_TXT_133645,FP 72 Recovery,FP 72 Recovery
+PROPITEM_TXT_133645,FP 72 Recovery,Ibinabalik ang 72 FP
 PROPITEM_TXT_133646,VitalDrink 200 (C),VitalDrink 200 (C)
-PROPITEM_TXT_133647,FP 144 Recovery,FP 144 Recovery
+PROPITEM_TXT_133647,FP 144 Recovery,Ibinabalik ang 144 FP
 PROPITEM_TXT_133648,VitalDrink 200 (B),VitalDrink 200 (B)
 PROPITEM_TXT_133649,VitalDrink 200 (A),VitalDrink 200 (A)
 PROPITEM_TXT_133650,VitalDrink 200 (A+),VitalDrink 200 (A+)
-PROPITEM_TXT_133651,FP 156 Recovery,FP 156 Recovery
+PROPITEM_TXT_133651,FP 156 Recovery,Ibinabalik ang 156 FP
 PROPITEM_TXT_133652,First Refresher (C),First Refresher (C)
-PROPITEM_TXT_133653,MP 78 Recovery,MP 78 Recovery
+PROPITEM_TXT_133653,MP 78 Recovery,Ibinabalik ang 78 MP
 PROPITEM_TXT_133654,Gray Pill (C),Gray Pill (C)
-PROPITEM_TXT_133655,Recovers 1320 HP,Recovers 1320 HP
+PROPITEM_TXT_133655,Recovers 1320 HP,Ibinabalik ang 1320 HP
 PROPITEM_TXT_133656,Gray Pill (B),Gray Pill (B)
 PROPITEM_TXT_133657,Gray Pill (A),Gray Pill (A)
 PROPITEM_TXT_133658,Gray Pill (A+),Gray Pill (A+)
-PROPITEM_TXT_133659,Recovers 1380 HP,Recovers 1380 HP
+PROPITEM_TXT_133659,Recovers 1380 HP,Ibinabalik ang 1380 HP
 PROPITEM_TXT_133660,Second Refresher (C),Second Refresher (C)
-PROPITEM_TXT_133661,MP 150 Recovery,MP 150 Recovery
+PROPITEM_TXT_133661,MP 150 Recovery,Ibinabalik ang 150 MP
 PROPITEM_TXT_133662,Second Refresher (B),Second Refresher (B)
 PROPITEM_TXT_133663,Second Refresher (A),Second Refresher (A)
 PROPITEM_TXT_133664,Second Refresher (A+),Second Refresher (A+)
-PROPITEM_TXT_133665,MP 163 Recovery,MP 163 Recovery
+PROPITEM_TXT_133665,MP 163 Recovery,Ibinabalik ang 163 MP
 PROPITEM_TXT_133666,VitalDrink 300 (C),VitalDrink 300 (C)
-PROPITEM_TXT_133667,FP 216 Recovery,FP 216 Recovery
+PROPITEM_TXT_133667,FP 216 Recovery,Ibinabalik ang 216 FP
 PROPITEM_TXT_133668,VitalDrink 300 (B),VitalDrink 300 (B)
 PROPITEM_TXT_133669,VitalDrink 300 (A),VitalDrink 300 (A)
 PROPITEM_TXT_133670,VitalDrink 300 (A+),VitalDrink 300 (A+)
-PROPITEM_TXT_133671,FP 234 Recovery,FP 234 Recovery
+PROPITEM_TXT_133671,FP 234 Recovery,Ibinabalik ang 234 FP
 PROPITEM_TXT_133672,VitalDrink 400 (C),VitalDrink 400 (C)
-PROPITEM_TXT_133673,FP 288 Recovery,FP 288 Recovery
+PROPITEM_TXT_133673,FP 288 Recovery,Ibinabalik ang 288 FP
 PROPITEM_TXT_133674,VitalDrink 400 (B),VitalDrink 400 (B)
 PROPITEM_TXT_133675,VitalDrink 400 (A),VitalDrink 400 (A)
 PROPITEM_TXT_133676,VitalDrink 400 (A+),VitalDrink 400 (A+)
-PROPITEM_TXT_133677,FP 312 Recovery,FP 312 Recovery
+PROPITEM_TXT_133677,FP 312 Recovery,Ibinabalik ang 312 FP
 PROPITEM_TXT_133678,VitalDrink 500 (C),VitalDrink 500 (C)
-PROPITEM_TXT_133679,FP 360 Recovery,FP 360 Recovery
+PROPITEM_TXT_133679,FP 360 Recovery,Ibinabalik ang 360 FP
 PROPITEM_TXT_133680,VitalDrink 500 (B),VitalDrink 500 (B)
 PROPITEM_TXT_133681,VitalDrink 500 (A),VitalDrink 500 (A)
 PROPITEM_TXT_133682,VitalDrink 500 (A+),VitalDrink 500 (A+)
-PROPITEM_TXT_133683,FP 390 Recovery,FP 390 Recovery
+PROPITEM_TXT_133683,FP 390 Recovery,Ibinabalik ang 390 FP
 PROPITEM_TXT_133684,VitalDrink 600 (C),VitalDrink 600 (C)
-PROPITEM_TXT_133685,FP 442 Recovery,FP 442 Recovery
+PROPITEM_TXT_133685,FP 442 Recovery,Ibinabalik ang 442 FP
 PROPITEM_TXT_133686,VitalDrink 600 (B),VitalDrink 600 (B)
 PROPITEM_TXT_133687,VitalDrink 600 (A),VitalDrink 600 (A)
 PROPITEM_TXT_133688,VitalDrink 600 (A+),VitalDrink 600 (A+)
-PROPITEM_TXT_133689,FP 478 Recovery,FP 478 Recovery
+PROPITEM_TXT_133689,FP 478 Recovery,Ibinabalik ang 478 FP
 PROPITEM_TXT_133690,VitalDrink 700 (C),VitalDrink 700 (C)
-PROPITEM_TXT_133691,FP 540 Recovery,FP 540 Recovery
+PROPITEM_TXT_133691,FP 540 Recovery,Ibinabalik ang 540 FP
 PROPITEM_TXT_133692,VitalDrink 700 (B),VitalDrink 700 (B)
 PROPITEM_TXT_133693,VitalDrink 700 (A),VitalDrink 700 (A)
 PROPITEM_TXT_133694,VitalDrink 700 (A+),VitalDrink 700 (A+)
-PROPITEM_TXT_133695,FP 585 Recovery,FP 585 Recovery
+PROPITEM_TXT_133695,FP 585 Recovery,Ibinabalik ang 585 FP
 PROPITEM_TXT_133696,VitalDrink 800 (C),VitalDrink 800 (C)
-PROPITEM_TXT_133697,FP 624 Recovery,FP 624 Recovery
+PROPITEM_TXT_133697,FP 624 Recovery,Ibinabalik ang 624 FP
 PROPITEM_TXT_133698,VitalDrink 800 (B),VitalDrink 800 (B)
 PROPITEM_TXT_133699,VitalDrink 800 (A),VitalDrink 800 (A)
 PROPITEM_TXT_133700,VitalDrink 800 (A+),VitalDrink 800 (A+)
-PROPITEM_TXT_133701,FP 676 Recovery,FP 676 Recovery
+PROPITEM_TXT_133701,FP 676 Recovery,Ibinabalik ang 676 FP
 PROPITEM_TXT_133702,Yellow Pill (C),Yellow Pill (C)
-PROPITEM_TXT_133703,Recovers 2200 HP,Recovers 2200 HP
+PROPITEM_TXT_133703,Recovers 2200 HP,Ibinabalik ang 2200 HP
 PROPITEM_TXT_133704,Yellow Pill (B),Yellow Pill (B)
 PROPITEM_TXT_133705,Yellow Pill (A),Yellow Pill (A)
 PROPITEM_TXT_133706,Yellow Pill (A+),Yellow Pill (A+)
-PROPITEM_TXT_133707,Recovers 2300 HP,Recovers 2300 HP
+PROPITEM_TXT_133707,Recovers 2300 HP,Ibinabalik ang 2300 HP
 PROPITEM_TXT_133708,Blue Pill (C),Blue Pill (C)
-PROPITEM_TXT_133709,Recovers 4400 HP,Recovers 4400 HP
+PROPITEM_TXT_133709,Recovers 4400 HP,Ibinabalik ang 4400 HP
 PROPITEM_TXT_133710,Blue Pill (B),Blue Pill (B)
 PROPITEM_TXT_133711,Blue Pill (A),Blue Pill (A)
 PROPITEM_TXT_133712,Blue Pill (A+),Blue Pill (A+)
-PROPITEM_TXT_133713,Recovers 4600 HP,Recovers 4600 HP
+PROPITEM_TXT_133713,Recovers 4600 HP,Ibinabalik ang 4600 HP
 PROPITEM_TXT_133714,Red Pill (C),Red Pill (C)
-PROPITEM_TXT_133715,Recovers 8800 HP,Recovers 8800 HP
+PROPITEM_TXT_133715,Recovers 8800 HP,Ibinabalik ang 8800 HP
 PROPITEM_TXT_133716,Red Pill (B),Red Pill (B)
 PROPITEM_TXT_133717,Red Pill (A),Red Pill (A)
 PROPITEM_TXT_133718,Red Pill (A+),Red Pill (A+)
-PROPITEM_TXT_133719,Recovers 9200 HP,Recovers 9200 HP
+PROPITEM_TXT_133719,Recovers 9200 HP,Ibinabalik ang 9200 HP
 PROPITEM_TXT_133720,Third Refresher (C),Third Refresher (C)
-PROPITEM_TXT_133721,MP 222 Recovery,MP 222 Recovery
+PROPITEM_TXT_133721,MP 222 Recovery,Ibinabalik ang 222 MP
 PROPITEM_TXT_133722,Third Refresher (B),Third Refresher (B)
 PROPITEM_TXT_133723,Third Refresher (A),Third Refresher (A)
 PROPITEM_TXT_133724,Third Refresher (A+),Third Refresher (A+)
-PROPITEM_TXT_133725,MP 241 Recovery,MP 241 Recovery
+PROPITEM_TXT_133725,MP 241 Recovery,Ibinabalik ang 241 MP
 PROPITEM_TXT_133726,Fourth Refresher (C),Fourth Refresher (C)
-PROPITEM_TXT_133727,MP 294 Recovery,MP 294 Recovery
+PROPITEM_TXT_133727,MP 294 Recovery,Ibinabalik ang 294 MP
 PROPITEM_TXT_133728,Fourth Refresher (B),Fourth Refresher (B)
 PROPITEM_TXT_133729,Fourth Refresher (A),Fourth Refresher (A)
 PROPITEM_TXT_133730,Fourth Refresher (A+),Fourth Refresher (A+)
-PROPITEM_TXT_133731,MP 319 Recovery,MP 319 Recovery
+PROPITEM_TXT_133731,MP 319 Recovery,Ibinabalik ang 319 MP
 PROPITEM_TXT_133732,Fifth Refresher (C),Fifth Refresher (C)
-PROPITEM_TXT_133733,MP 378 Recovery,MP 378 Recovery
+PROPITEM_TXT_133733,MP 378 Recovery,Ibinabalik ang 378 MP
 PROPITEM_TXT_133734,Fifth Refresher (B),Fifth Refresher (B)
 PROPITEM_TXT_133735,Fifth Refresher (A),Fifth Refresher (A)
 PROPITEM_TXT_133736,Fifth Refresher (A+),Fifth Refresher (A+)
-PROPITEM_TXT_133737,MP 410 Recovery,MP 410 Recovery
+PROPITEM_TXT_133737,MP 410 Recovery,Ibinabalik ang 410 MP
 PROPITEM_TXT_133738,Sixth Refresher (C),Sixth Refresher (C)
-PROPITEM_TXT_133739,MP 450 Recovery,MP 450 Recovery
+PROPITEM_TXT_133739,MP 450 Recovery,Ibinabalik ang 450 MP
 PROPITEM_TXT_133740,Sixth Refresher (B),Sixth Refresher (B)
 PROPITEM_TXT_133741,Sixth Refresher (A),Sixth Refresher (A)
 PROPITEM_TXT_133742,Sixth Refresher (A+),Sixth Refresher (A+)
-PROPITEM_TXT_133743,MP 488 Recovery,MP 488 Recovery
+PROPITEM_TXT_133743,MP 488 Recovery,Ibinabalik ang 488 MP
 PROPITEM_TXT_133744,Seventh Refresher (C),Seventh Refresher (C)
-PROPITEM_TXT_133745,MP 540 Recovery,MP 540 Recovery
+PROPITEM_TXT_133745,MP 540 Recovery,Ibinabalik ang 540 MP
 PROPITEM_TXT_133746,Seventh Refresher (B),Seventh Refresher (B)
 PROPITEM_TXT_133747,Seventh Refresher (A),Seventh Refresher (A)
 PROPITEM_TXT_133748,Seventh Refresher (A+),Seventh Refresher (A+)
-PROPITEM_TXT_133749,MP 585 Recovery,MP 585 Recovery
+PROPITEM_TXT_133749,MP 585 Recovery,Ibinabalik ang 585 MP
 PROPITEM_TXT_133750,VitalDrink 900 (C),VitalDrink 900 (C)
-PROPITEM_TXT_133751,FP 708 Recovery,FP 708 Recovery
+PROPITEM_TXT_133751,FP 708 Recovery,Ibinabalik ang 708 FP
 PROPITEM_TXT_133752,VitalDrink 900 (B),VitalDrink 900 (B)
 PROPITEM_TXT_133753,VitalDrink 900 (A),VitalDrink 900 (A)
 PROPITEM_TXT_133754,VitalDrink 900 (A+),VitalDrink 900 (A+)
-PROPITEM_TXT_133755,FP 767 Recovery,FP 767 Recovery
+PROPITEM_TXT_133755,FP 767 Recovery,Ibinabalik ang 767 FP
 PROPITEM_TXT_133756,Ninth Refresher (C),Ninth Refresher (C)
-PROPITEM_TXT_133757,MP 720 Recovery,MP 720 Recovery
+PROPITEM_TXT_133757,MP 720 Recovery,Ibinabalik ang 720 MP
 PROPITEM_TXT_133758,Ninth Refresher (B),Ninth Refresher (B)
 PROPITEM_TXT_133759,Ninth Refresher (A),Ninth Refresher (A)
 PROPITEM_TXT_133760,Ninth Refresher (A+),Ninth Refresher (A+)
-PROPITEM_TXT_133761,MP 780 Recovery,MP 780 Recovery
+PROPITEM_TXT_133761,MP 780 Recovery,Ibinabalik ang 780 MP
 PROPITEM_TXT_133762,Tenth Refresher (C),Tenth Refresher (C)
-PROPITEM_TXT_133763,MP 810 Recovery,MP 810 Recovery
+PROPITEM_TXT_133763,MP 810 Recovery,Ibinabalik ang 810 MP
 PROPITEM_TXT_133764,Tenth Refresher (B),Tenth Refresher (B)
 PROPITEM_TXT_133765,Tenth Refresher (A),Tenth Refresher (A)
 PROPITEM_TXT_133766,Tenth Refresher (A+),Tenth Refresher (A+)
-PROPITEM_TXT_133767,MP 878 Recovery,MP 878 Recovery
+PROPITEM_TXT_133767,MP 878 Recovery,Ibinabalik ang 878 MP
 PROPITEM_TXT_133768,Gold Pill (C),Gold Pill (C)
-PROPITEM_TXT_133769,Recovers 16500 HP,Recovers 16500 HP
+PROPITEM_TXT_133769,Recovers 16500 HP,Ibinabalik ang 16500 HP
 PROPITEM_TXT_133770,Gold Pill (B),Gold Pill (B)
 PROPITEM_TXT_133771,Gold Pill (A),Gold Pill (A)
 PROPITEM_TXT_133772,Gold Pill (A+),Gold Pill (A+)
-PROPITEM_TXT_133773,Recovers 17250 HP,Recovers 17250 HP
+PROPITEM_TXT_133773,Recovers 17250 HP,Ibinabalik ang 17250 HP
 PROPITEM_TXT_133774,Shining Gold Pill,Shining Gold Pill
 PROPITEM_TXT_133775,A shining gold pill.,A shining gold pill.
 PROPITEM_TXT_133776,Shining Gold Pill (C),Shining Gold Pill (C)
@@ -19056,7 +19056,7 @@ PROPITEM_TXT_134672,Brilliant Amethyst,Brilliant Amethyst
 PROPITEM_TXT_134673,Sausage Casserole (B),Sausage Casserole (B)
 PROPITEM_TXT_134674,Sausage Casserole (A),Sausage Casserole (A)
 PROPITEM_TXT_134675,Sausage Casserole (A+),Sausage Casserole (A+)
-PROPITEM_TXT_134676,Recovers 481 HP,Recovers 481 HP
+PROPITEM_TXT_134676,Recovers 481 HP,Ibinabalik ang 481 HP
 PROPITEM_TXT_726143,[Event] Pumpkin Ball,[Event] Pumpkin Ball
 PROPITEM_TXT_726144,"The Pumpkin Ball contains a mysterious substance, and when thrown at a pumpkin, it will neutralize the pumpkin.","The Pumpkin Ball contains a mysterious substance, and when thrown at a pumpkin, it will neutralize the pumpkin."
 PROPITEM_TXT_726145,[Event] Pumpkin Treat Box,[Event] Pumpkin Treat Box
@@ -23359,11 +23359,11 @@ PROPITEM_TXT_134822,A Select Box filled with FWC snack items. You can choose 1 i
 PROPITEM_TXT_134823,2025 FWC PopCorn Select box,2025 FWC PopCorn Select box
 PROPITEM_TXT_134824,A Select Box filled with variety FWC buff items. You can choose 1 item from it,A Select Box filled with variety FWC buff items. You can choose 1 item from it
 PROPITEM_TXT_134825,FWC Red Hot Fries,FWC Red Hot Fries
-PROPITEM_TXT_134826,Recovers 9999 HP,Recovers 9999 HP
+PROPITEM_TXT_134826,Recovers 9999 HP,Ibinabalik ang 9999 HP
 PROPITEM_TXT_134827,FWC BBQ Fries,FWC BBQ Fries
-PROPITEM_TXT_134828,Recovers 9999 FP,Recovers 9999 FP
+PROPITEM_TXT_134828,Recovers 9999 FP,Ibinabalik ang 9999 FP
 PROPITEM_TXT_134829,FWC Sparkling Lemon Water,FWC Sparkling Lemon Water
-PROPITEM_TXT_134830,Recovers 9999 MP,Recovers 9999 MP
+PROPITEM_TXT_134830,Recovers 9999 MP,Ibinabalik ang 9999 MP
 PROPITEM_TXT_134831,FWC Special combo,FWC Special combo
 PROPITEM_TXT_134832,20% HP recovered upon use,20% HP recovered upon use
 PROPITEM_TXT_134833,2025 FWC Red PopCorn,2025 FWC Red PopCorn


### PR DESCRIPTION
Some Item descriptions for Recover HP/MP/FP changed, and also some minor item name changes.

### Description
Hard to say this, I translated Filipino item description for Recover HP/FP/MP (including such as First Refresher, VitalDrink 100, Milk, etc.).

To be fair, Filipino was indeed which is also known as Tagalog. feel free to review.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
