### PR TITLE
[Japanese] Translate remaining entries in Dialogs.csv and TextClient.csv

### DIFF
--- a/Japanese/Dialogs.csv
+++ b/Japanese/Dialogs.csv
@@ -1,7 +1,7 @@
 ﻿Key,English,Japanese
 NPC_WHOAREYOU,Who are you?,紹介
 NPC_GOODBYE,Goodbye!,さようなら
-NPC_CARGO,CARGO,CARGO
+NPC_CARGO,CARGO,貨物
 NPC_WHATSGOINGON,What's going on?,近況
 NPC_EXIT,Exit,出る方法
 NPC_HOWTOFLY,How to Fly,飛行操縦
@@ -90,7 +90,7 @@ NPC_000097,"I hope the information I gave you was helpful. You're on your own no
 NPC_000098,"1. Occasionally, you will run into some pesky masquerpets while flying. You will see a red box surrounding them.",1. 空を飛んでいると、空中でもモンスターに出くわすことがあるの。たまに怒って攻撃されるかもしれないから、くれぐれも気を付けることね。
 NPC_000099,"2. You can target these creatures with the Left Mouse Button. If you lose sight of them while flying, a green arrow appears on the edge of the screen to indicate which direction you need to turn. ",2. ターゲットする対象をクリックすると狙うことができるわ。もし飛行中に相手を見失っても、画面の端に緑色の矢印が表示されて、行くべき方向が示されるはずよ。
 NPC_000100,"3. To attack the creature, simply get as close as you can and press the Left Mouse Button or the Insert Key.\n 4. If you want to follow the monster automatically, press the Z Key.",3. ターゲッティングしたモンスターに近づき、マウス左ボタンをクリックすると攻撃ができるわ。\n 4. モンスターをターゲットしている状態でZキーを押すと、目標を自動的に追いかけることができるわよ。
-NPC_000101,5. Magicians and Acrobats can shoot from range while in the air. Mercenaries and Assists must rely on melee attacks. You can also use your skills!,5. Magicians and Acrobats can shoot from range while in the air. Mercenaries and Assists must rely on melee attacks. You can also use your skills!
+NPC_000101,5. Magicians and Acrobats can shoot from range while in the air. Mercenaries and Assists must rely on melee attacks. You can also use your skills!,5. マジシャンとアクロバットは空中から遠距離攻撃ができます。マーシナリーとアシストは近接攻撃に頼る必要があります。スキルも使えますよ！
 NPC_000102,"6. When you destroy a flying masquerpet, any dropped loot will be placed into your inventory automatically. If there is no room in your inventory, the loot is lost, so be careful!",6. 飛行中のモンスターを倒した時は、ドロップしたアイテムが自動でインベントリに入るから安心してね。でも、もしインベントリに空きがなかったら消えてしまうからそこは要注意よ！
 NPC_000103,"7. That about covers it for your flying combat training, cadet! Just one more thing... Don't crash and burn! Hahaha, just a little pilot humor.",7. これであなたはもう一人前ね！そうそう、最後に1つだけ。きれいなお姉さんを見つけたからって、よそ見運転なんか絶対やめてね？事故起こされたらたまったもんじゃないわ。えへへ、冗談よ。
 NPC_000104,Have fun out there and be safe! Don't forget to check your six!,カッコ良く飛び回りながら、スリル溢れる空中戦を楽しんでくださいね！
@@ -864,10 +864,10 @@ NPC_001046,"Hey, you two! Stop that bickering, it's pointless! Take it to the ar
 NPC_001047,"In the PvP arena, you can fight other adventurers such as yourself. If you meet unfortunate circumstances, and are slain on the arena floor, you will not incur any death penalties.",アリーナは1次転職を終えたヤツらが自由に闘うことのできる場所だ。力試しだと思って挑戦してみろ。
 NPC_001048,My name is Lay and I am in charge of the PvP arena. I'll only let you in if you've chosen your first job.,私はアリーナの入場を管理しているレイだ。アリーナに入場するなら話かけてくれ。
 NPC_001049,Another one bites the dust!,自信を持って生きるんだ。
-NPC_001050,Why don't you sign up for a Madrigal tournament right away? Prove you are the best.,Why don't you sign up for a Madrigal tournament right away? Prove you are the best.
-NPC_001051,"Madrigal Tournament is about to begin. Hurry, to the arena!","Madrigal Tournament is about to begin. Hurry, to the arena!"
-NPC_001052,Would you like to take a bet on who will win this tournament?,Would you like to take a bet on who will win this tournament?
-NPC_001053,The odds have been released. Check the payout for the team you bet on.,The odds have been released. Check the payout for the team you bet on.
+NPC_001050,Why don't you sign up for a Madrigal tournament right away? Prove you are the best.,マドリガルトーナメントに今すぐ登録してみない？自分が最強だって証明してみせてよ。
+NPC_001051,"Madrigal Tournament is about to begin. Hurry, to the arena!",マドリガルトーナメントがまもなく始まります！急いでアリーナへ！
+NPC_001052,Would you like to take a bet on who will win this tournament?,このトーナメントの勝者に賭けてみませんか？
+NPC_001053,The odds have been released. Check the payout for the team you bet on.,オッズが発表されました。賭けたチームの配当を確認してください。
 NPC_001078,Only the strongest of guilds can achieve victory in the Secret Room!,勇気のあるギルドは、ギルド・オルタナティヴに挑戦を！
 NPC_001079,"If your guild is top ranked in the Secret Room, you will receive weekly rewards!",あなたのギルドがオルタナティヴでトップランクにある場合、あなたは毎週報酬を受け取ります!
 NPC_001080,"Hello, adventurer! I'm in charge of the Secret Room and the Forsaken Tower. If you have any questions about this heroic challenge, please don't hesitate to ask. ",俺様はバリトン。東部地域のギルド・オルタナティヴを担当している。ギルド・オルタナティヴに関連することは全て俺に聞いてくれ。あと、東部の税率も教えてやるぞ？ガッハッハ。
@@ -880,7 +880,7 @@ NPC_001090,Would anyone like a jewel crafted or perhaps a jewelry setting create
 NPC_001091,"Hi there! I offer jewelry services to the citizens of Flarine and create and set jewels for those wishing to modify their Rare Weapons. I also remove blessings and level reductions from items, among other things!",宝石はあなたの力をより強くしてくれるの。宝石の作成やユニーク武器への変換は私に任せてください。レベル減少の解除も私が適任ね。あぁ宝石ってステキ･･･。
 NPC_001092,My name is Peach! I'm here to assist Boboku and help supplement his upgrading business. Stop by anytime!,アタシはピーチ！最近、ボボタ先輩の仕事が多くなっちゃって、仕方なくアタシが手伝いに来たってわけ。彼らにできないことはアタシができるから、いつでも声かけてな～！
 NPC_001093,"Take care. Remember, for anything to do with jewels, I'm your girl!",宝石は素晴らしいわぁ。この美しさ、たまらないでしょう？
-NPC_001130,We're running out of time! The newly appointed lord will be here soon!,We're running out of time! The newly appointed lord will be here soon!
+NPC_001130,We're running out of time! The newly appointed lord will be here soon!,時間がありません！新しく任命された領主がもうすぐここに来ます！
 NPC_001219,Attention everyone! We are looking for new Mentors. I will get you started on your way to becoming a Mentor!,マドリガルの有能な人材を捜しています。心当たりのある方はいませんか？
 NPC_001220,Come see me if you want to become a Mentor. ,「師匠」になるには、まず私の話を聞いてください。
 NPC_001221,"It is not easy to find worthy people to walk the path of a Mentor, it isn't for everyone.",有能な人材を捜すのはとても難しいことですね…。
@@ -989,7 +989,7 @@ NPC_100042,Welcome to Azria!,アズリアへようこそ！
 NPC_100043,"Stay safe out there, traveler.",旅人さん、どうかお気をつけて。
 NPC_100044,Stay safe.,おげんきで。
 NPC_100045,Hm... Yes...,うーん...はい...
-NPC_100046,...,...
+NPC_100046,...,……
 NPC_100047,May Rhisis be with you.,リシスがあなたと共にありますように。
 NPC_100048,You should not be here...,あなたはここにいるべきではありません...
 NPC_100049,Volkane is an ancient and once forgotten cavern in the depths of Magmient. The air is filled with volcanic ash and hot gases. This is no place for you.,ヴォルケインはマガミエントの奥深くにある、かつては忘れ去られていた古代の洞窟です。空気は火山灰と高温ガスで満たされています。ここはあなたのための場所ではありません。
@@ -1064,7 +1064,7 @@ NPC_100117,"Ah! You've brought everything needed to cleanse the evil from your b
 NPC_100118,,
 NPC_100119,,
 NPC_100120,,
-NPC_100121,Who is gonna attend the #bfinals in Manila#nb and win the #bFlyff World Championship 2026#nb? Prove that you are the best!,Who is gonna attend the #bfinals in Manila#nb and win the #bFlyff World Championship 2026#nb? Prove that you are the best!
+NPC_100121,Who is gonna attend the #bfinals in Manila#nb and win the #bFlyff World Championship 2026#nb? Prove that you are the best!,#bマニラ決勝戦#nb に出場し、#bFlyff World チャンピオンシップ2026#nb で優勝するのは誰だ？お前が一番だということを証明してみせろ！
 NPC_100122,"Welcome, competitor! I am Ava, the manager of the Flyff World Championship. I will trade you the best equipment you can get to win the competition!",ようこそ、ライバル!私はフリフワールドチャンピオンシップのマネージャーであるアヴァです。競争に勝つために手に入れることができる最高の機器を交換します!
 NPC_100123,"Hm I can feel that you are the best PvE competitor! No, wait... Maybe PvP? Ha I don't know. Good luck!",うーん、あなたは最高のPvE競技者であると感じます!待たないでいいです。。。PvPかな?はぁ、わかんない。がんばって！
 NPC_100124,May the best win!,最高の勝利がありますように!
@@ -1126,259 +1126,259 @@ NPC_100178,Happy New Year~!\nMay the new year of 2024 be full of fun adventures!
 NPC_100179,"Hi! I would like to ask you a favor, could you hear me out?",こんにちは！お願いがあるのですが、聞いてもらえますか?
 NPC_100180,"Have you heard of the rumor? The rumor that a blacksmith made a couple ring thinking only about his beloved until he died after losing her in an accident! When lovers put on the couple's ring and think about going to their lover, they fly to their lover in an instant, which is amazing, isn't it?",その噂を聞いたことがありますか?ある鍛冶屋が、事故で彼女を失って亡くなるまで、最愛の人のことだけを考えてカップルリングを作ったという噂!恋人同士が夫婦の指輪をはめて恋人のところへ行こうと思うと、一瞬で恋人のところに飛んでいく、すごいですよね。
 NPC_100181,Do you want to exit the dungeon?,ダンジョンから出ますか?
-NPC_100182,"Did you know that the more you polish seashells in the sea, the more beautiful they become? I once saw seashells that were very highly polished. It was so beautiful.\nI know where I can get the materials I need to polish clams. Can you get the material there and polish the shells? It's dangerous, but it might be a great vacation for you","Did you know that the more you polish seashells in the sea, the more beautiful they become? I once saw seashells that were very highly polished. It was so beautiful.\nI know where I can get the materials I need to polish clams. Can you get the material there and polish the shells? It's dangerous, but it might be a great vacation for you"
-NPC_100183,"It's the 20th anniversary of Flyff! How are you celebrating this lovely occasion? I'm going to be reminiscing, reading up on all kinds of history...","It's the 20th anniversary of Flyff! How are you celebrating this lovely occasion? I'm going to be reminiscing, reading up on all kinds of history..."
-NPC_100184,"In order for me to give you a quest, all partners of your couple must be online!","In order for me to give you a quest, all partners of your couple must be online!"
-NPC_100185,"I am Cupid, the messenger of love sent from the heavens. I've been dispatched to fill Madrigal with love. If you have someone you love, don't hesitate, confess your feelings using a ring!","I am Cupid, the messenger of love sent from the heavens. I've been dispatched to fill Madrigal with love. If you have someone you love, don't hesitate, confess your feelings using a ring!"
-NPC_100186,"Hello there. Enjoying your life in Madrigal? If you wish to expand your horizons, come see me.","Hello there. Enjoying your life in Madrigal? If you wish to expand your horizons, come see me."
-NPC_100187,"Speaking of me, I'm a master of thousand crafts. Herbs, trees, ores, fish, anything you don't know about this world, ask me. I'll tell you all about it.","Speaking of me, I'm a master of thousand crafts. Herbs, trees, ores, fish, anything you don't know about this world, ask me. I'll tell you all about it."
-NPC_100188,We reuse our food - of course joking!,We reuse our food - of course joking!
-NPC_100189,Hello there! I may have something useful for you. Would you mind taking a look in my bag?,Hello there! I may have something useful for you. Would you mind taking a look in my bag?
-NPC_100190,I'm just walking around and selling stuff.,I'm just walking around and selling stuff.
-NPC_100191,"I don't know what items will be available when, so come back whenever you have time. Hehe","I don't know what items will be available when, so come back whenever you have time. Hehe"
-NPC_100192,"Arrr, ye got that look in yer eye! Reminds me of when I was a young scallywag, barely old enough to tie me own boots. There I was, face to face with a storm that could sink the fiercest ship. But here I am, still breathin'! Takes a bit o' grit to survive out here, but I reckon ye've got what it takes.","Arrr, ye got that look in yer eye! Reminds me of when I was a young scallywag, barely old enough to tie me own boots. There I was, face to face with a storm that could sink the fiercest ship. But here I am, still breathin'! Takes a bit o' grit to survive out here, but I reckon ye've got what it takes."
-NPC_100193,"Ahoy! Captain Sovann, scourge o’ the seas of Madrigal! I’ve clashed blades and cannons in countless battles, and more than a few of 'em against the dark forces of Shade herself. Ain't many who could boast survivin’ such encounters! If there’s danger to face or treasure to seize, ye can bet ol' Sovann’s been there!","Ahoy! Captain Sovann, scourge o’ the seas of Madrigal! I’ve clashed blades and cannons in countless battles, and more than a few of 'em against the dark forces of Shade herself. Ain't many who could boast survivin’ such encounters! If there’s danger to face or treasure to seize, ye can bet ol' Sovann’s been there!"
-NPC_100194,"As ye embark on yer journey through these treacherous waters and enchanted lands, remember Madrigal’s beauty is as deadly as it is mesmerizing. Stay sharp, bold traveler, for adventure may beckon, but danger lurks beneath every wave. Fare thee well, and may the tides favor ye till we cross paths again!","As ye embark on yer journey through these treacherous waters and enchanted lands, remember Madrigal’s beauty is as deadly as it is mesmerizing. Stay sharp, bold traveler, for adventure may beckon, but danger lurks beneath every wave. Fare thee well, and may the tides favor ye till we cross paths again!"
-NPC_100195,"Ahoy! Fresh faces like yers bring new fire to these old sails. With a mate like ye, I just might find the spark for me next grand venture on the high seas!","Ahoy! Fresh faces like yers bring new fire to these old sails. With a mate like ye, I just might find the spark for me next grand venture on the high seas!"
-NPC_100196,"Sailing the high seas is more than just a test of strengt it’s an art, a blend of courage, wit, and the call o’ the unknown. If yer heart yearns for the thrill of discovery and the clash of steel, know that I’ll be here, ready to welcome ye on ventures wild and grand!","Sailing the high seas is more than just a test of strengt it’s an art, a blend of courage, wit, and the call o’ the unknown. If yer heart yearns for the thrill of discovery and the clash of steel, know that I’ll be here, ready to welcome ye on ventures wild and grand!"
-NPC_100197,"Uncover the secrets within the Revolutionary Journal, and great rewards await you","Uncover the secrets within the Revolutionary Journal, and great rewards await you"
-NPC_150001,"I mean… what could really happen in a place this quiet? A short break won’t hurt, right?","I mean… what could really happen in a place this quiet? A short break won’t hurt, right?"
-NPC_150002,"My name’s Doran. I’m an airport guard… though it’s honestly duller than I expected. You’re from across the sea, right? Seen anything interesting?","My name’s Doran. I’m an airport guard… though it’s honestly duller than I expected. You’re from across the sea, right? Seen anything interesting?"
-NPC_150003,"I don’t recognize any of you. Who are you? You’re not one of those wolves, are you?","I don’t recognize any of you. Who are you? You’re not one of those wolves, are you?"
-NPC_150004,"I'm Chiron, a soldier stationed here. We can forgive an old man for failing a mission, but not for neglecting his watch.","I'm Chiron, a soldier stationed here. We can forgive an old man for failing a mission, but not for neglecting his watch."
-NPC_150005,"Hey, look at those clouds. Doesn’t that one look like a cat’s face?","Hey, look at those clouds. Doesn’t that one look like a cat’s face?"
-NPC_150006,"Hey there, I’m Bran! Sometimes listening is more important than guarding… don’t you think?","Hey there, I’m Bran! Sometimes listening is more important than guarding… don’t you think?"
-NPC_150007,"This airport feels safe, doesn’t it? But have you ever seen fire fall from the sky where you thought you were safe?","This airport feels safe, doesn’t it? But have you ever seen fire fall from the sky where you thought you were safe?"
-NPC_150008,"I'm Karr. If you drop your guard during wartime, that moment might be your last.","I'm Karr. If you drop your guard during wartime, that moment might be your last."
-NPC_150009,…Do you need something?,…Do you need something?
-NPC_150010,My name’s Zerke. Keep your questions short. I’ll help if I can.,My name’s Zerke. Keep your questions short. I’ll help if I can.
-NPC_150011,"It feels good to protect something, doesn’t it?","It feels good to protect something, doesn’t it?"
-NPC_150012,I'm Elin. My job is to make sure everyone coming through here stays safe.,I'm Elin. My job is to make sure everyone coming through here stays safe.
-NPC_150013,Protecting a village isn’t simple. All those lives rest on us.,Protecting a village isn’t simple. All those lives rest on us.
-NPC_150014,I am Gard. I’m one of the guardians who protect this place.,I am Gard. I’m one of the guardians who protect this place.
-NPC_150015,"Hello! Beautiful morning, isn’t it? I’m Gard.","Hello! Beautiful morning, isn’t it? I’m Gard."
-NPC_150016,"Even cats need a break sometimes. Still, patrol never stops.","Even cats need a break sometimes. Still, patrol never stops."
-NPC_150017,"I’m Liont. If my jokes get old, bear with me. I’ll keep this village safe.","I’m Liont. If my jokes get old, bear with me. I’ll keep this village safe."
-NPC_150018,Why am I a guard? Because it’s cool. Simple as that.,Why am I a guard? Because it’s cool. Simple as that.
-NPC_150019,War? I’m not afraid of it. I’ll fight until my last breath.,War? I’m not afraid of it. I’ll fight until my last breath.
-NPC_150020,I’m Serkan. Need a reason to fight? I don’t. I just enjoy facing strong enemies.,I’m Serkan. Need a reason to fight? I don’t. I just enjoy facing strong enemies.
-NPC_150021,Let’s make today a good one. Victory awaits.,Let’s make today a good one. Victory awaits.
-NPC_150022,Why don’t those dogs come near us? Easy. They’re scared of our claws.,Why don’t those dogs come near us? Easy. They’re scared of our claws.
-NPC_150023,Call me Kras. I protect this village.,Call me Kras. I protect this village.
-NPC_150024,I used to be an adventurer like you… until I took an arrow to the knee.,I used to be an adventurer like you… until I took an arrow to the knee.
-NPC_150025,A new face. I hope we stay on friendly terms.,A new face. I hope we stay on friendly terms.
-NPC_150026,"I’m Maeron. I’ve fought for a long time, and I’ll keep fighting until we win.","I’m Maeron. I’ve fought for a long time, and I’ll keep fighting until we win."
-NPC_150027,You’re not ready.,You’re not ready.
-NPC_150028,Great day for patrol. Is there even such a thing as bad weather? Not for me.,Great day for patrol. Is there even such a thing as bad weather? Not for me.
-NPC_150029,My name’s Kerion. I’m on patrol—let me know if you spot anything odd.,My name’s Kerion. I’m on patrol—let me know if you spot anything odd.
-NPC_150030,"Go, adventurer… go.","Go, adventurer… go."
-NPC_150031,"It’s wonderful seeing everyone living in peace, isn’t it?","It’s wonderful seeing everyone living in peace, isn’t it?"
-NPC_150032,I’m Raon! No one loves this village more than me.,I’m Raon! No one loves this village more than me.
-NPC_150033,You can’t pass.,You can’t pass.
-NPC_150034,"Stay calm. If the soldiers panic, who will the villagers rely on?","Stay calm. If the soldiers panic, who will the villagers rely on?"
-NPC_150035,"I am Dreon, Captain Baron’s loyal left hand. Everything I do is for this village.","I am Dreon, Captain Baron’s loyal left hand. Everything I do is for this village."
-NPC_150036,The guy next to me? He’s connected. Says he’s friends with someone named Waldo.\nDo you know who that is?,The guy next to me? He’s connected. Says he’s friends with someone named Waldo.\nDo you know who that is?
-NPC_150037,"You’ve made it this far… but from here on, things might get dangerous.","You’ve made it this far… but from here on, things might get dangerous."
-NPC_150038,"I’m Merk, head of scouting. Seen any Lycan activity?","I’m Merk, head of scouting. Seen any Lycan activity?"
-NPC_150039,Quiet. Scouting only works if we stay hidden.,Quiet. Scouting only works if we stay hidden.
-NPC_150040,"Protecting the village is an honor, but never easy—especially when those beasts outside keep baring their fangs.","Protecting the village is an honor, but never easy—especially when those beasts outside keep baring their fangs."
-NPC_150041,"I am Baron, captain of Eillun’s guards. As the shield and sword of this place, I won’t allow any threat near our people. Under my command, no one slacks off.","I am Baron, captain of Eillun’s guards. As the shield and sword of this place, I won’t allow any threat near our people. Under my command, no one slacks off."
-NPC_150042,The Lycans are growing bolder. Keep your weapon ready.,The Lycans are growing bolder. Keep your weapon ready.
-NPC_150043,This village has a long history… a very long one. But you don’t need to know everything. Sometimes knowledge becomes a burden.,This village has a long history… a very long one. But you don’t need to know everything. Sometimes knowledge becomes a burden.
-NPC_150044,"I am Gaurang, the Jarl. I’ve protected this village for decades. My bones ache with age, yet the afterlife still refuses to take me. Strange, isn’t it?","I am Gaurang, the Jarl. I’ve protected this village for decades. My bones ache with age, yet the afterlife still refuses to take me. Strange, isn’t it?"
-NPC_150045,Welcome to Eillun Village. I hope you enjoy your stay.,Welcome to Eillun Village. I hope you enjoy your stay.
-NPC_150046,A new visitor… Let’s hope that’s a good sign.,A new visitor… Let’s hope that’s a good sign.
-NPC_150047,"I am Ayr, one of the elders. I’ve helped uphold this village for a long time. It’s been harder lately, though. Maybe you’ll bring change.","I am Ayr, one of the elders. I’ve helped uphold this village for a long time. It’s been harder lately, though. Maybe you’ll bring change."
-NPC_150048,sigh The jarl threw his work at me again today…\nI’m too old for this. Can’t even retire quietly.,sigh The jarl threw his work at me again today…\nI’m too old for this. Can’t even retire quietly.
-NPC_150049,Do you always trust what you see? Think it through.,Do you always trust what you see? Think it through.
-NPC_150050,"I’m Elder Traitus, in charge of supplies. Now then… how am I supposed to find enough for today?","I’m Elder Traitus, in charge of supplies. Now then… how am I supposed to find enough for today?"
-NPC_150051,We’re not like the Khajiit… not like them at all.,We’re not like the Khajiit… not like them at all.
-NPC_150052,"Sometimes protecting the village requires sacrifice. It’s harsh, but true.","Sometimes protecting the village requires sacrifice. It’s harsh, but true."
-NPC_150053,"I’m Melak, responsible for security with Baron. Things get worse every day. Please don’t give me another reason to worry. I’ll be keeping an eye on you.","I’m Melak, responsible for security with Baron. Things get worse every day. Please don’t give me another reason to worry. I’ll be keeping an eye on you."
-NPC_150054,It’s dangerous to go alone.,It’s dangerous to go alone.
-NPC_150055,How long are we going to sit around? We need to strike back and show them who we are.,How long are we going to sit around? We need to strike back and show them who we are.
-NPC_150056,I am Silar. There’s one way to protect this village: make our enemies fear us more than we fear them.,I am Silar. There’s one way to protect this village: make our enemies fear us more than we fear them.
-NPC_150057,We have a great communicator here… want to guess who?,We have a great communicator here… want to guess who?
-NPC_150058,"Is a long life a blessing? Stay too long in a place you were meant to leave, and the ground starts to feel like it’s sinking under you.","Is a long life a blessing? Stay too long in a place you were meant to leave, and the ground starts to feel like it’s sinking under you."
-NPC_150059,"I’m Ebron, just an old man with too much spare time. Live long enough and you start noticing things others don’t.","I’m Ebron, just an old man with too much spare time. Live long enough and you start noticing things others don’t."
-NPC_150060,"Time is a strange thing, isn’t it?","Time is a strange thing, isn’t it?"
-NPC_150061,Stock up on supplies before you leave. Better to have too much than too little.,Stock up on supplies before you leave. Better to have too much than too little.
-NPC_150062,"I’m Liana, owner of the general store. Traveler or villager, I’ll make sure you get what you need.","I’m Liana, owner of the general store. Traveler or villager, I’ll make sure you get what you need."
-NPC_150063,"Hand over the Penya peacefully, and no one gets hurt.","Hand over the Penya peacefully, and no one gets hurt."
-NPC_150064,Look at this gemstone! It’s not just jewelry—it’s art.,Look at this gemstone! It’s not just jewelry—it’s art.
-NPC_150065,"I’m Teron. When it comes to gems, my eyes are sharper than anyone’s. I can find the perfect one for you.","I’m Teron. When it comes to gems, my eyes are sharper than anyone’s. I can find the perfect one for you."
-NPC_150066,Jewels are art! Do you appreciate art? Train your eye—your skills might improve along with it.,Jewels are art! Do you appreciate art? Train your eye—your skills might improve along with it.
-NPC_150067,Good armor is like having a second life.,Good armor is like having a second life.
-NPC_150068,I’m Haret. Picking armor isn’t about preference—it’s survival. Think you’ll find better quality anywhere else? Doubt it.,I’m Haret. Picking armor isn’t about preference—it’s survival. Think you’ll find better quality anywhere else? Doubt it.
-NPC_150069,You won’t find armor like this anywhere else. Buy today and I’ll even give you a small discount.,You won’t find armor like this anywhere else. Buy today and I’ll even give you a small discount.
-NPC_150070,A good weapon never betrays its wielder. Find one that suits you.,A good weapon never betrays its wielder. Find one that suits you.
-NPC_150071,"Name’s Domir. Swords, axes, bows—whatever you need, I can forge it.","Name’s Domir. Swords, axes, bows—whatever you need, I can forge it."
-NPC_150072,You sure you’re happy with that weapon? You deserve better. Let me show you something nice.,You sure you’re happy with that weapon? You deserve better. Let me show you something nice.
-NPC_150073,"Attacking is important, but if you can’t defend yourself, you won’t last a battle.","Attacking is important, but if you can’t defend yourself, you won’t last a battle."
-NPC_150074,"I’m Toran, the best shieldsmith in the village. If you need a shield crafted, I’m your guy.","I’m Toran, the best shieldsmith in the village. If you need a shield crafted, I’m your guy."
-NPC_150075,"That shield won’t last long out here. Lucky for you, I’ve got a sturdier one.","That shield won’t last long out here. Lucky for you, I’ve got a sturdier one."
-NPC_150076,Fresh off the fire! I’ve even got a warm pot of soup. Want a bowl?,Fresh off the fire! I’ve even got a warm pot of soup. Want a bowl?
-NPC_150077,"I’m Karen, the best cook in the village. And no, my secret recipes aren’t going anywhere.","I’m Karen, the best cook in the village. And no, my secret recipes aren’t going anywhere."
-NPC_150078,Fresh goods from the forest! Stock up before you travel.,Fresh goods from the forest! Stock up before you travel.
-NPC_150079,A staff or wand is just a tool. The real magic depends on the person holding it.,A staff or wand is just a tool. The real magic depends on the person holding it.
-NPC_150080,"I’m Nebrah, seller of magical tools. If you know how to handle these properly, they’ll bring great power.","I’m Nebrah, seller of magical tools. If you know how to handle these properly, they’ll bring great power."
-NPC_150081,"Interested in magic? I’ve got wands, staves, robes—take a look.","Interested in magic? I’ve got wands, staves, robes—take a look."
-NPC_150082,Color carries emotion. The flowers around here create shades no dye can match.,Color carries emotion. The flowers around here create shades no dye can match.
-NPC_150083,I’m Sena. I dye fabrics with flowers and plants. Your clothes would look beautiful with my colors.,I’m Sena. I dye fabrics with flowers and plants. Your clothes would look beautiful with my colors.
-NPC_150084,Take a look.,Take a look.
-NPC_150085,Wounds heal with time… but the right treatment helps a lot.,Wounds heal with time… but the right treatment helps a lot.
-NPC_150086,"I’m Rohan. I tend to the injured. It used to be peaceful work, but lately it’s been exhausting.","I’m Rohan. I tend to the injured. It used to be peaceful work, but lately it’s been exhausting."
-NPC_150087,"Time is money, friend.","Time is money, friend."
-NPC_150088,"Knowledge is the strongest weapon. Those beasts fight with teeth, but we defeat them with wit.","Knowledge is the strongest weapon. Those beasts fight with teeth, but we defeat them with wit."
-NPC_150089,I’m Belia. I teach young Myurans our history and wisdom. Learning never ends.,I’m Belia. I teach young Myurans our history and wisdom. Learning never ends.
-NPC_150090,"If you want to share knowledge with us, you’d better learn our unit system. The YP Law is pretty great, honestly.","If you want to share knowledge with us, you’d better learn our unit system. The YP Law is pretty great, honestly."
-NPC_150091,The stars reveal many things. Tonight’s constellations hint at change.,The stars reveal many things. Tonight’s constellations hint at change.
-NPC_150092,"I’m Kerin. I read the stars for glimpses of the future. Your fate… well, I’m not supposed to say.","I’m Kerin. I read the stars for glimpses of the future. Your fate… well, I’m not supposed to say."
-NPC_150093,But I do believe you’re strong enough to face whatever comes.,But I do believe you’re strong enough to face whatever comes.
-NPC_150094,Hunting isn’t just catching prey—it’s understanding nature.,Hunting isn’t just catching prey—it’s understanding nature.
-NPC_150095,"I’m Artin, the village hunter. I bring in fresh meat. Those dogs make it harder lately, but it’s still my job.","I’m Artin, the village hunter. I bring in fresh meat. Those dogs make it harder lately, but it’s still my job."
-NPC_150096,Wanna communicate with mother Nature? Follow me!,Wanna communicate with mother Nature? Follow me!
-NPC_150097,Trees are alive. I just help shape their lives into new forms.,Trees are alive. I just help shape their lives into new forms.
-NPC_150098,I’m Pael. I carve fallen branches from the great town tree. Their memories live through my work.,I’m Pael. I carve fallen branches from the great town tree. Their memories live through my work.
-NPC_150099,"To speak to living trees, you must use your true name and put your heart into it. I am Pael. I am Pael.","To speak to living trees, you must use your true name and put your heart into it. I am Pael. I am Pael."
-NPC_150100,Dreams send messages from within. Understanding them can reveal the truth.,Dreams send messages from within. Understanding them can reveal the truth.
-NPC_150101,I’m Lumi. I listen to people’s dreams and help them find meaning. Had any strange ones lately?,I’m Lumi. I listen to people’s dreams and help them find meaning. Had any strange ones lately?
-NPC_150102,Let me show you… a world of dreams and imagination.,Let me show you… a world of dreams and imagination.
-NPC_150103,The stars hold the stories of our ancestors. Their wisdom still guides us.,The stars hold the stories of our ancestors. Their wisdom still guides us.
-NPC_150104,"I’m Ivelyn. I study the constellations. If I learn enough, I might even predict when those dogs will attack.","I’m Ivelyn. I study the constellations. If I learn enough, I might even predict when those dogs will attack."
-NPC_150105,May the ancestors watch over you.,May the ancestors watch over you.
-NPC_150106,A scent can hold a memory. One drop of my perfume might bring back something long forgotten.,A scent can hold a memory. One drop of my perfume might bring back something long forgotten.
-NPC_150107,"I’m Selin, a maker of perfumes. I wonder which scent suits you best.","I’m Selin, a maker of perfumes. I wonder which scent suits you best."
-NPC_150108,The same fragrance smells different on everyone. That’s the magic of it.,The same fragrance smells different on everyone. That’s the magic of it.
-NPC_150109,Hey! Don’t tell the adults you saw me here. Seriously—don’t.,Hey! Don’t tell the adults you saw me here. Seriously—don’t.
-NPC_150110,"I'm Kaela. Go home? Not happening. Wolves or not, I can handle myself.","I'm Kaela. Go home? Not happening. Wolves or not, I can handle myself."
-NPC_150111,Grown-ups love saying “no.” It’s the one word I can’t stand.,Grown-ups love saying “no.” It’s the one word I can’t stand.
-NPC_150112,Every event carries a lesson. A good story makes it easier to hear.,Every event carries a lesson. A good story makes it easier to hear.
-NPC_150113,I’m Livia. I collect and share our people’s stories. Want to share yours?,I’m Livia. I collect and share our people’s stories. Want to share yours?
-NPC_150114,Old legends always hide clues—ways to survive today.,Old legends always hide clues—ways to survive today.
-NPC_150115,"One day… I’ll earn their respect, no matter what it takes.","One day… I’ll earn their respect, no matter what it takes."
-NPC_150116,"I’m Taila. It’s a secret, but I’m actually the jarl’s—…no, I shouldn’t say more.","I’m Taila. It’s a secret, but I’m actually the jarl’s—…no, I shouldn’t say more."
-NPC_150117,"If I say it out loud, I feel like everything might fall apart. So it stays a secret.","If I say it out loud, I feel like everything might fall apart. So it stays a secret."
-NPC_150118,What are you doing here? Most people don’t even know this place exists.,What are you doing here? Most people don’t even know this place exists.
-NPC_150119,You’re not ready to know the truth. But if you grow stronger… maybe that’ll change.,You’re not ready to know the truth. But if you grow stronger… maybe that’ll change.
-NPC_150120,Turn back. You’re not qualified.,Turn back. You’re not qualified.
-NPC_150121,"Where did we go so wrong!? It’s good they aren’t attacking, but still…","Where did we go so wrong!? It’s good they aren’t attacking, but still…"
-NPC_150122,"I'm Beck, from Saint City. I joined the New World Expedition and ended up stuck here. Missed the ship home, sadly.","I'm Beck, from Saint City. I joined the New World Expedition and ended up stuck here. Missed the ship home, sadly."
-NPC_150123,People—! A person is here! Help!,People—! A person is here! Help!
-NPC_150124,Keeping watch here isn’t easy. You never know what might creep out of the darkness.,Keeping watch here isn’t easy. You never know what might creep out of the darkness.
-NPC_150125,Me? I’m the guardian of Ankou’s Asylum. Someone has to make sure the nightmares stay inside.,Me? I’m the guardian of Ankou’s Asylum. Someone has to make sure the nightmares stay inside.
-NPC_150126,Feeling brave today? Just remember—I warned you.,Feeling brave today? Just remember—I warned you.
-NPC_150127,"If you make it through Ankou’s madness, come find me. I’d love to hear your story… assuming you’re still sane.","If you make it through Ankou’s madness, come find me. I’d love to hear your story… assuming you’re still sane."
-NPC_DUNGEONBUFF_000001,Earn 2 random Statue Effects (buffs or debuffs).,Earn 2 random Statue Effects (buffs or debuffs).
-NPC_DUNGEONBUFF_000002,Earn 1 Statue Buff (buff only).,Earn 1 Statue Buff (buff only).
-NPC_DUNGEONBUFF_000003,Change your current statue buff at random.,Change your current statue buff at random.
-NPC_150128,Just… leave me alone. I need to rest my eyes.,Just… leave me alone. I need to rest my eyes.
-NPC_150129,I thought I could face him alone… but he was much stronger than I expected. Please be ready if you plan to fight him.,I thought I could face him alone… but he was much stronger than I expected. Please be ready if you plan to fight him.
-NPC_150130,Alone… I didn't stand a chance.,Alone… I didn't stand a chance.
-NPC_150131,Very well. What do you need?,Very well. What do you need?
-NPC_150132,"Stay vigilant. In wartime, a moment's carelessness can be fatal.","Stay vigilant. In wartime, a moment's carelessness can be fatal."
-NPC_150133,Come see me if you're hurt. Proper treatment makes all the difference.,Come see me if you're hurt. Proper treatment makes all the difference.
-NPC_150134,Safety is my responsibility here. I take that duty seriously.,Safety is my responsibility here. I take that duty seriously.
-NPC_150135,"This place is quiet, but that doesn't mean we can let our guard down completely.","This place is quiet, but that doesn't mean we can let our guard down completely."
-NPC_150136,A soldier's watch must never fail. We protect this place with our lives.,A soldier's watch must never fail. We protect this place with our lives.
-NPC_150137,I hope your visit brings good fortune to our village.,I hope your visit brings good fortune to our village.
-NPC_150138,"Pay attention to what you hear. Sometimes the most important information comes when you're listening, not watching.","Pay attention to what you hear. Sometimes the most important information comes when you're listening, not watching."
-NPC_150139,"The ship left without me, but I can't dwell on that. Life goes on, and so must I.","The ship left without me, but I can't dwell on that. Life goes on, and so must I."
-NPC_150140,Quick question—can you handle a task for me?,Quick question—can you handle a task for me?
-NPC_150141,I need someone reliable. Think you're up for it?,I need someone reliable. Think you're up for it?
-NPC_150142,I've got injured people piling up. Could you help me gather some supplies?,I've got injured people piling up. Could you help me gather some supplies?
-NPC_150143,There's something dangerous out there. I need someone to investigate.,There's something dangerous out there. I need someone to investigate.
-NPC_150144,Bored of guard duty yet? I've got something more interesting if you're interested.,Bored of guard duty yet? I've got something more interesting if you're interested.
-NPC_150145,We've spotted suspicious activity. I need someone to check it out.,We've spotted suspicious activity. I need someone to check it out.
-NPC_150146,A visitor like you might be able to help with something the locals can't.,A visitor like you might be able to help with something the locals can't.
-NPC_150147,I overheard something important. Want to help me follow up on it?,I overheard something important. Want to help me follow up on it?
-NPC_150148,"I'm stuck here, but maybe you could help me with something back home?","I'm stuck here, but maybe you could help me with something back home?"
-NPC_150149,Our supplies are running low. Could you help me gather what we need?,Our supplies are running low. Could you help me gather what we need?
-NPC_150150,That shield you're carrying looks weak. I've got a job that might earn you a better one.,That shield you're carrying looks weak. I've got a job that might earn you a better one.
-NPC_150151,"I've found some interesting gems, but I need help appraising them properly.","I've found some interesting gems, but I need help appraising them properly."
-NPC_150152,"There's something I need to tell you… but first, can you help me with a small task?","There's something I need to tell you… but first, can you help me with a small task?"
-NPC_150153,Those Lycans are getting bolder. I need someone to help me track their movements.,Those Lycans are getting bolder. I need someone to help me track their movements.
-NPC_150154,I'm looking for a real fight. Think you can point me toward something challenging?,I'm looking for a real fight. Think you can point me toward something challenging?
-NPC_150155,I've been working on some new colors. Want to help me test them out?,I've been working on some new colors. Want to help me test them out?
-NPC_150156,I've been hearing strange things in people's dreams lately. Can you help me investigate?,I've been hearing strange things in people's dreams lately. Can you help me investigate?
-NPC_150157,More wounded keep coming in. I could really use some help gathering medical supplies.,More wounded keep coming in. I could really use some help gathering medical supplies.
-NPC_150158,"I love this village, but there's something I need help protecting.","I love this village, but there's something I need help protecting."
-NPC_150159,The trees have been whispering. They want me to find something. Will you help?,The trees have been whispering. They want me to find something. Will you help?
-NPC_150160,"I've got some powerful magic tools, but I need help testing them safely.","I've got some powerful magic tools, but I need help testing them safely."
-NPC_150161,You shouldn't be here. But since you are… maybe you can help me with something.,You shouldn't be here. But since you are… maybe you can help me with something.
-NPC_150162,I've spotted some unusual Lycan movements. Want to help me scout the area?,I've spotted some unusual Lycan movements. Want to help me scout the area?
-NPC_150163,I've been fighting for so long. Maybe you can help me finish this once and for all.,I've been fighting for so long. Maybe you can help me finish this once and for all.
-NPC_150164,I've been having strange dreams about you. Want to help me understand what they mean?,I've been having strange dreams about you. Want to help me understand what they mean?
-NPC_150165,"I collect stories, and I think yours might be worth hearing. But first, help me with something?","I collect stories, and I think yours might be worth hearing. But first, help me with something?"
-NPC_150166,"Those dogs won't come near us, but something else might. Want to help me keep watch?","Those dogs won't come near us, but something else might. Want to help me keep watch?"
-NPC_150167,"I'm on patrol, but I spotted something that needs investigating. Care to join me?","I'm on patrol, but I spotted something that needs investigating. Care to join me?"
-NPC_150168,The stars are telling me something important. I need your help to understand it.,The stars are telling me something important. I need your help to understand it.
-NPC_150169,"I've got fresh food ready, but I need help delivering it to some people. Interested?","I've got fresh food ready, but I need help delivering it to some people. Interested?"
-NPC_150170,"Hey, don't tell anyone you saw me, but I could use your help with something.","Hey, don't tell anyone you saw me, but I could use your help with something."
-NPC_150171,This village has secrets. I might share one if you help me with a task.,This village has secrets. I might share one if you help me with a task.
-NPC_150172,"I've been watching the constellations. Something's coming, and I need help preparing.","I've been watching the constellations. Something's coming, and I need help preparing."
-NPC_150173,I've got injured soldiers who need better armor. Can you help me gather materials?,I've got injured soldiers who need better armor. Can you help me gather materials?
-NPC_150174,"I thought I could handle it alone, but I was wrong. Can you help me finish what I started?","I thought I could handle it alone, but I was wrong. Can you help me finish what I started?"
-NPC_150175,"The stars have shown me something about you. Help me, and I'll tell you what I saw.","The stars have shown me something about you. Help me, and I'll tell you what I saw."
-NPC_150176,Good armor saves lives. I need help getting materials to make more. Can you assist?,Good armor saves lives. I need help getting materials to make more. Can you assist?
-NPC_150177,"I'm loyal to Captain Baron, but there's something I need to handle personally. Will you help?","I'm loyal to Captain Baron, but there's something I need to handle personally. Will you help?"
-NPC_150178,"I've lived too long in one place. Help me with this, and maybe I can finally move on.","I've lived too long in one place. Help me with this, and maybe I can finally move on."
-NPC_150179,"I've been teaching the young ones, but there's something I need to learn myself. Can you help?","I've been teaching the young ones, but there's something I need to learn myself. Can you help?"
-NPC_150180,"I forge weapons, but I need rare materials. Think you can help me find them?","I forge weapons, but I need rare materials. Think you can help me find them?"
-NPC_150181,"The village needs protection, and I need someone I can trust. Are you that person?","The village needs protection, and I need someone I can trust. Are you that person?"
-NPC_150182,"I'm an elder, and I've seen many things. Help me with this, and I'll share what I know.","I'm an elder, and I've seen many things. Help me with this, and I'll share what I know."
-NPC_150183,The nightmares are getting stronger. I need someone brave enough to help me contain them.,The nightmares are getting stronger. I need someone brave enough to help me contain them.
-NPC_150184,Hunting's been tough lately. I could use help tracking down some prey.,Hunting's been tough lately. I could use help tracking down some prey.
-NPC_150185,Security is getting worse every day. I need someone to help me investigate a threat.,Security is getting worse every day. I need someone to help me investigate a threat.
-NPC_150186,Welcome to the #b#cffff0000Eillun Quest Office#nc#nb! Looking for work? I may have a job for you...,Welcome to the #b#cffff0000Eillun Quest Office#nc#nb! Looking for work? I may have a job for you...
+NPC_100182,"Did you know that the more you polish seashells in the sea, the more beautiful they become? I once saw seashells that were very highly polished. It was so beautiful.\nI know where I can get the materials I need to polish clams. Can you get the material there and polish the shells? It's dangerous, but it might be a great vacation for you",海で貝殻を磨けば磨くほど美しくなるって知ってた？前にすごく磨き込まれた貝殻を見たことがあるんだ。本当に綺麗だったよ。\n貝を磨くのに必要な材料がどこで手に入るか知ってるんだ。そこで材料を集めて、貝殻を磨いてきてくれないか？危険だけど、いい息抜きになるかもしれないよ
+NPC_100183,"It's the 20th anniversary of Flyff! How are you celebrating this lovely occasion? I'm going to be reminiscing, reading up on all kinds of history...",Flyffの20周年だよ！この素敵な日をどうやって祝う？僕はいろんな歴史を読み返して思い出に浸るつもりさ……
+NPC_100184,"In order for me to give you a quest, all partners of your couple must be online!",クエストを渡すには、あなたのカップルのパートナー全員がオンラインである必要があります！
+NPC_100185,"I am Cupid, the messenger of love sent from the heavens. I've been dispatched to fill Madrigal with love. If you have someone you love, don't hesitate, confess your feelings using a ring!",私は天から遣わされた愛の使者、キューピッドです。マドリガルを愛で満たすために遣わされました。愛する人がいるなら、ためらわずリングを使って想いを伝えなさい！
+NPC_100186,"Hello there. Enjoying your life in Madrigal? If you wish to expand your horizons, come see me.",こんにちは。マドリガルでの生活を楽しんでいますか？視野を広げたいなら、私に会いに来てください。
+NPC_100187,"Speaking of me, I'm a master of thousand crafts. Herbs, trees, ores, fish, anything you don't know about this world, ask me. I'll tell you all about it.",私と言えば、あらゆる技に通じた達人です。薬草、木、鉱石、魚……この世界について知らないことがあれば、何でも聞いてください。すべてお教えします。
+NPC_100188,We reuse our food - of course joking!,食べ物は再利用してるんだ――なんてね、冗談だよ！
+NPC_100189,Hello there! I may have something useful for you. Would you mind taking a look in my bag?,こんにちは！何か役に立つものがあるかもしれません。私のカバンの中を覗いてみませんか？
+NPC_100190,I'm just walking around and selling stuff.,ただ歩き回って物を売っているだけですよ。
+NPC_100191,"I don't know what items will be available when, so come back whenever you have time. Hehe",いつ何が手に入るかは私にも分からないので、時間のある時にまた来てください。へへ
+NPC_100192,"Arrr, ye got that look in yer eye! Reminds me of when I was a young scallywag, barely old enough to tie me own boots. There I was, face to face with a storm that could sink the fiercest ship. But here I am, still breathin'! Takes a bit o' grit to survive out here, but I reckon ye've got what it takes.",おお、その目つき……いいねぇ！わしがまだ駆け出しの悪童で、自分のブーツもろくに結べなかった頃を思い出すぜ。あの時は、どんな猛者の船でも沈めちまいそうな嵐と真正面から向き合ったもんさ。だが見ろ、わしはまだこうして息をしてる！ここで生き延びるにはちいとばかし度胸が要るが、お前さんにはそれがありそうだな。
+NPC_100193,"Ahoy! Captain Sovann, scourge o’ the seas of Madrigal! I’ve clashed blades and cannons in countless battles, and more than a few of 'em against the dark forces of Shade herself. Ain't many who could boast survivin’ such encounters! If there’s danger to face or treasure to seize, ye can bet ol' Sovann’s been there!",よお！マドリガルの海の脅威、キャプテン・ソヴァンだ！数えきれねぇ戦いで剣と大砲を交えてきたし、その中にはシェイドの闇の勢力との戦いも少なくねぇ。そんな戦いを生き延びたって言える奴はそういねぇだろうよ！危険に立ち向かうにしろ、宝を手に入れるにしろ、このソヴァンならとっくに経験済みだぜ！
+NPC_100194,"As ye embark on yer journey through these treacherous waters and enchanted lands, remember Madrigal’s beauty is as deadly as it is mesmerizing. Stay sharp, bold traveler, for adventure may beckon, but danger lurks beneath every wave. Fare thee well, and may the tides favor ye till we cross paths again!",この危険な海と魔法の地を旅するなら、覚えておけ。マドリガルの美しさは、その魅惑的な姿と同じくらい命取りにもなる。気を抜くなよ、勇敢な旅人よ。冒険はお前を誘うだろうが、波の下には危険が潜んでる。それじゃあな、また会う日まで潮がお前に味方しますように！
+NPC_100195,"Ahoy! Fresh faces like yers bring new fire to these old sails. With a mate like ye, I just might find the spark for me next grand venture on the high seas!",よお！お前さんみたいな新しい顔ぶれは、この古びた帆に新しい火をくれるもんだ。お前さんのような仲間がいれば、次の壮大な航海への火種が見つかるかもしれねぇな！
+NPC_100196,"Sailing the high seas is more than just a test of strengt it’s an art, a blend of courage, wit, and the call o’ the unknown. If yer heart yearns for the thrill of discovery and the clash of steel, know that I’ll be here, ready to welcome ye on ventures wild and grand!",大海原を渡るってのは、ただの力試しじゃねぇ。勇気と機知、そして未知への呼び声が織りなす芸術さ。発見の興奮と剣の激突に心が疼くなら、覚えておけ。わしはいつでもここにいて、荒々しくも壮大な冒険にお前を迎え入れる準備ができてるぜ！
+NPC_100197,"Uncover the secrets within the Revolutionary Journal, and great rewards await you",革命の日誌に隠された秘密を暴け。豪華な報酬がお前を待っている
+NPC_150001,"I mean… what could really happen in a place this quiet? A short break won’t hurt, right?",……こんな静かな場所で、一体何が起きるっていうんだ？少し休んだって構わないよな？
+NPC_150002,"My name’s Doran. I’m an airport guard… though it’s honestly duller than I expected. You’re from across the sea, right? Seen anything interesting?",俺の名前はドラン。空港の衛兵をやっている……思ってたよりずっと退屈な仕事だけどな。お前さん、海の向こうから来たのか？何か面白いものは見なかったか？
+NPC_150003,"I don’t recognize any of you. Who are you? You’re not one of those wolves, are you?",お前たちのことは知らないな。何者だ？まさか、あの狼どもの一味じゃないだろうな？
+NPC_150004,"I'm Chiron, a soldier stationed here. We can forgive an old man for failing a mission, but not for neglecting his watch.",俺はカイロン、ここに配属された兵士だ。任務に失敗した老兵は許されても、見張りを怠った者は許されない。
+NPC_150005,"Hey, look at those clouds. Doesn’t that one look like a cat’s face?",おい、あの雲を見てみろ。あれ、猫の顔に見えないか？
+NPC_150006,"Hey there, I’m Bran! Sometimes listening is more important than guarding… don’t you think?",やあ、俺はブラン！時には見張るより、耳を傾ける方が大事なこともある……そう思わないか？
+NPC_150007,"This airport feels safe, doesn’t it? But have you ever seen fire fall from the sky where you thought you were safe?",この空港は安全に感じるだろ？でも、安全だと思っていた場所に空から火が降ってくるのを見たことはあるか？
+NPC_150008,"I'm Karr. If you drop your guard during wartime, that moment might be your last.",俺はカー。戦時中に気を抜けば、その瞬間が命取りになるかもしれない。
+NPC_150009,…Do you need something?,……何か用か？
+NPC_150010,My name’s Zerke. Keep your questions short. I’ll help if I can.,俺の名前はザーク。質問は手短に頼む。できる限り力になろう。
+NPC_150011,"It feels good to protect something, doesn’t it?",何かを守るってのは、いい気分だろ？
+NPC_150012,I'm Elin. My job is to make sure everyone coming through here stays safe.,私はエリン。ここを通る皆の安全を守るのが仕事です。
+NPC_150013,Protecting a village isn’t simple. All those lives rest on us.,村を守るのは簡単なことじゃない。すべての命が私たちにかかっているんだ。
+NPC_150014,I am Gard. I’m one of the guardians who protect this place.,私はガード。この場所を守る守護者の一人だ。
+NPC_150015,"Hello! Beautiful morning, isn’t it? I’m Gard.",こんにちは！いい朝ですね？私はガードです。
+NPC_150016,"Even cats need a break sometimes. Still, patrol never stops.",猫だってたまには休憩が必要さ。とはいえ、パトロールは止まらないけどな。
+NPC_150017,"I’m Liont. If my jokes get old, bear with me. I’ll keep this village safe.",私はリオント。私の冗談が古くさくても勘弁してくれ。この村は俺が守るからな。
+NPC_150018,Why am I a guard? Because it’s cool. Simple as that.,なぜ衛兵になったかって？かっこいいからさ。それだけだよ。
+NPC_150019,War? I’m not afraid of it. I’ll fight until my last breath.,戦争？怖くなんかない。最後の一息まで戦い抜くさ。
+NPC_150020,I’m Serkan. Need a reason to fight? I don’t. I just enjoy facing strong enemies.,私はセルカン。戦う理由が要るかって？いらないね。強い敵と向き合うのが、ただ好きなだけさ。
+NPC_150021,Let’s make today a good one. Victory awaits.,今日をいい日にしよう。勝利は目前だ。
+NPC_150022,Why don’t those dogs come near us? Easy. They’re scared of our claws.,なんであの犬どもは俺たちに近づいてこないと思う？簡単さ。俺たちの爪を恐れてるのさ。
+NPC_150023,Call me Kras. I protect this village.,私はクラス。この村を守っている。
+NPC_150024,I used to be an adventurer like you… until I took an arrow to the knee.,俺も昔はお前みたいな冒険者だったんだが……膝に矢を受けてしまってな。
+NPC_150025,A new face. I hope we stay on friendly terms.,新しい顔だな。友好的な関係を築けるといいが。
+NPC_150026,"I’m Maeron. I’ve fought for a long time, and I’ll keep fighting until we win.",私はメイロン。長いこと戦ってきたが、勝利するまで戦い続けるつもりだ。
+NPC_150027,You’re not ready.,お前はまだ準備ができていない。
+NPC_150028,Great day for patrol. Is there even such a thing as bad weather? Not for me.,パトロール日和だな。悪天候なんてものがそもそもあるのか？少なくとも俺には関係ないね。
+NPC_150029,My name’s Kerion. I’m on patrol—let me know if you spot anything odd.,私の名前はケリオン。パトロール中だ――何か変わったものを見かけたら教えてくれ。
+NPC_150030,"Go, adventurer… go.",行け、冒険者よ……行くんだ。
+NPC_150031,"It’s wonderful seeing everyone living in peace, isn’t it?",みんなが平和に暮らしているのを見るのは、素晴らしいことだよな？
+NPC_150032,I’m Raon! No one loves this village more than me.,私はラオン！この村を私ほど愛している者はいない！
+NPC_150033,You can’t pass.,お前は通れない。
+NPC_150034,"Stay calm. If the soldiers panic, who will the villagers rely on?",落ち着け。兵士が慌てたら、村人たちは誰を頼ればいい？
+NPC_150035,"I am Dreon, Captain Baron’s loyal left hand. Everything I do is for this village.",私はドレオン、バロン隊長の忠実な左腕だ。私のすることはすべて、この村のためにある。
+NPC_150036,The guy next to me? He’s connected. Says he’s friends with someone named Waldo.\nDo you know who that is?,隣にいるあいつ？顔が広いらしいぜ。ワルドとかいう奴と知り合いだって言ってた。\nそいつが誰か知ってるか？
+NPC_150037,"You’ve made it this far… but from here on, things might get dangerous.",ここまでよく来たな……だが、ここから先は危険が増すかもしれない。
+NPC_150038,"I’m Merk, head of scouting. Seen any Lycan activity?",私はメルク、斥候隊長だ。ライカンの動きを見なかったか？
+NPC_150039,Quiet. Scouting only works if we stay hidden.,静かに。斥候の仕事は隠れていてこそ成り立つんだ。
+NPC_150040,"Protecting the village is an honor, but never easy—especially when those beasts outside keep baring their fangs.",村を守るのは誇り高いことだが、簡単じゃない――特に、外にいるあの獣どもが牙をむき続けている限りはな。
+NPC_150041,"I am Baron, captain of Eillun’s guards. As the shield and sword of this place, I won’t allow any threat near our people. Under my command, no one slacks off.",私はバロン、エルリウン衛兵の隊長だ。この地の盾であり剣である以上、住民に迫るいかなる脅威も許しはしない。私の指揮下では、誰一人怠けることは許されない。
+NPC_150042,The Lycans are growing bolder. Keep your weapon ready.,ライカンどもが大胆になってきている。武器をいつでも使えるようにしておけ。
+NPC_150043,This village has a long history… a very long one. But you don’t need to know everything. Sometimes knowledge becomes a burden.,この村には長い歴史がある……とても長い歴史がな。だが、お前がすべてを知る必要はない。時に知識は重荷になる。
+NPC_150044,"I am Gaurang, the Jarl. I’ve protected this village for decades. My bones ache with age, yet the afterlife still refuses to take me. Strange, isn’t it?",私はガウラング、ヤールだ。何十年もこの村を守ってきた。年老いた体は軋むが、あの世はまだ私を迎えてくれないらしい。奇妙なものだろう？
+NPC_150045,Welcome to Eillun Village. I hope you enjoy your stay.,エルリウン村へようこそ。滞在を楽しんでくれ。
+NPC_150046,A new visitor… Let’s hope that’s a good sign.,新しい客人か……いい兆しだといいが。
+NPC_150047,"I am Ayr, one of the elders. I’ve helped uphold this village for a long time. It’s been harder lately, though. Maybe you’ll bring change.",私はエア、長老の一人だ。長いことこの村を支えてきた。だが最近はどんどん難しくなっている。もしかすると、お前が変化をもたらしてくれるかもしれないな。
+NPC_150048,sigh The jarl threw his work at me again today…\nI’m too old for this. Can’t even retire quietly.,（ため息）今日もまたヤールに仕事を押し付けられた……\n年寄りにはきついよ。静かに引退することもできやしない。
+NPC_150049,Do you always trust what you see? Think it through.,いつも見たものをそのまま信じるのか？よく考えてみるといい。
+NPC_150050,"I’m Elder Traitus, in charge of supplies. Now then… how am I supposed to find enough for today?",私はトレイタス長老、物資の管理を任されている。さて……今日の分をどうやって工面したものか。
+NPC_150051,We’re not like the Khajiit… not like them at all.,私たちはカジートとは違う……まったく違う。
+NPC_150052,"Sometimes protecting the village requires sacrifice. It’s harsh, but true.",村を守るには、時に犠牲が必要だ。厳しいが、それが真実だ。
+NPC_150053,"I’m Melak, responsible for security with Baron. Things get worse every day. Please don’t give me another reason to worry. I’ll be keeping an eye on you.",私はメラク、バロンと共に治安を担当している。日に日に状況は悪化している。頼むから、これ以上心配の種を増やさないでくれ。お前のことは見張らせてもらう。
+NPC_150054,It’s dangerous to go alone.,一人で行くのは危険だぞ。
+NPC_150055,How long are we going to sit around? We need to strike back and show them who we are.,いつまでこうして座っているつもりだ？反撃に出て、俺たちの力を見せつける必要がある。
+NPC_150056,I am Silar. There’s one way to protect this village: make our enemies fear us more than we fear them.,私はサイラー。この村を守る方法は一つしかない――敵が俺たちを恐れる以上に、俺たちが敵を恐れないことだ。
+NPC_150057,We have a great communicator here… want to guess who?,ここには話がうまい奴がいるんだ……誰だと思う？
+NPC_150058,"Is a long life a blessing? Stay too long in a place you were meant to leave, and the ground starts to feel like it’s sinking under you.",長生きは祝福なのか？去るべき場所に長くとどまりすぎると、足元の地面が沈んでいくように感じ始める。
+NPC_150059,"I’m Ebron, just an old man with too much spare time. Live long enough and you start noticing things others don’t.",私はエブロン、ただの暇を持て余した老人さ。長く生きていると、他人が気づかないことに気づくようになるものだ。
+NPC_150060,"Time is a strange thing, isn’t it?",時というのは、奇妙なものだろう？
+NPC_150061,Stock up on supplies before you leave. Better to have too much than too little.,旅立つ前に物資を蓄えておけ。多すぎるくらいがちょうどいい。
+NPC_150062,"I’m Liana, owner of the general store. Traveler or villager, I’ll make sure you get what you need.",私はリアナ、雑貨店の店主です。旅人でも村人でも、必要なものは必ずお渡しします。
+NPC_150063,"Hand over the Penya peacefully, and no one gets hurt.",大人しくペニャを渡せば、誰も痛い目には遭わない。
+NPC_150064,Look at this gemstone! It’s not just jewelry—it’s art.,この宝石を見てくれ！ただの装飾品じゃない――芸術品だ。
+NPC_150065,"I’m Teron. When it comes to gems, my eyes are sharper than anyone’s. I can find the perfect one for you.",私はテロン。宝石にかけては、誰よりも目が利く自信がある。あなたにぴったりの一品を見つけてあげよう。
+NPC_150066,Jewels are art! Do you appreciate art? Train your eye—your skills might improve along with it.,宝石は芸術だ！芸術を分かるかい？目を鍛えれば、腕前も一緒に磨かれるかもしれないよ。
+NPC_150067,Good armor is like having a second life.,良い防具は、まるでもう一つの命を持つようなものだ。
+NPC_150068,I’m Haret. Picking armor isn’t about preference—it’s survival. Think you’ll find better quality anywhere else? Doubt it.,私はハレット。防具選びは好みの問題じゃない――生死を分ける問題だ。他所でこれ以上の品質が見つかると思うか？まさかな。
+NPC_150069,You won’t find armor like this anywhere else. Buy today and I’ll even give you a small discount.,こんな防具、他ではまず手に入らないぞ。今日買ってくれるなら、ちょっとしたおまけもつけよう。
+NPC_150070,A good weapon never betrays its wielder. Find one that suits you.,良い武器は、使い手を決して裏切らない。自分に合う一振りを見つけろ。
+NPC_150071,"Name’s Domir. Swords, axes, bows—whatever you need, I can forge it.",私はドミール。剣も斧も弓も、必要なものは何でも打ってやろう。
+NPC_150072,You sure you’re happy with that weapon? You deserve better. Let me show you something nice.,本当にその武器で満足なのか？お前ならもっといいものにふさわしい。何かいいものを見せてやろう。
+NPC_150073,"Attacking is important, but if you can’t defend yourself, you won’t last a battle.",攻撃も大事だが、自分の身を守れなければ戦いを乗り切れない。
+NPC_150074,"I’m Toran, the best shieldsmith in the village. If you need a shield crafted, I’m your guy.",私はトラン、この村一番の盾職人だ。盾を打ってほしければ、私に任せろ。
+NPC_150075,"That shield won’t last long out here. Lucky for you, I’ve got a sturdier one.",その盾はここじゃ長持ちしない。運がいいことに、もっと頑丈なやつを用意してあるぞ。
+NPC_150076,Fresh off the fire! I’ve even got a warm pot of soup. Want a bowl?,焼きたてだよ！温かいスープも用意してある。一杯どうだい？
+NPC_150077,"I’m Karen, the best cook in the village. And no, my secret recipes aren’t going anywhere.",私はカレン、この村一番の料理人さ。それと、秘伝のレシピは誰にも教えないからね。
+NPC_150078,Fresh goods from the forest! Stock up before you travel.,森から届いたばかりの新鮮な品だよ！旅立つ前に買いだめしておきな。
+NPC_150079,A staff or wand is just a tool. The real magic depends on the person holding it.,杖や魔導具はただの道具にすぎない。本当の魔力は、それを扱う者次第だ。
+NPC_150080,"I’m Nebrah, seller of magical tools. If you know how to handle these properly, they’ll bring great power.",私はネブラ、魔法道具を売っている。正しい扱い方を知っていれば、これらは大きな力をもたらしてくれる。
+NPC_150081,"Interested in magic? I’ve got wands, staves, robes—take a look.",魔法に興味があるのかい？杖に魔導書、ローブも取り揃えてるよ。見ていくといい。
+NPC_150082,Color carries emotion. The flowers around here create shades no dye can match.,色には感情が宿る。この辺りに咲く花は、どんな染料にも出せない色合いを生み出すんだ。
+NPC_150083,I’m Sena. I dye fabrics with flowers and plants. Your clothes would look beautiful with my colors.,私はセナ。花や植物で布を染めているの。私の色なら、あなたの服もきっと美しく映えるわ。
+NPC_150084,Take a look.,見ていって。
+NPC_150085,Wounds heal with time… but the right treatment helps a lot.,傷は時間とともに癒えるけれど……正しい治療があれば、ずっと早くなるわ。
+NPC_150086,"I’m Rohan. I tend to the injured. It used to be peaceful work, but lately it’s been exhausting.",私はロハン。怪我人の手当てをしている。昔は穏やかな仕事だったけど、最近は本当に大変なの。
+NPC_150087,"Time is money, friend.",時は金なり、だよ。
+NPC_150088,"Knowledge is the strongest weapon. Those beasts fight with teeth, but we defeat them with wit.",知識こそ最強の武器だ。あの獣どもは牙で戦うが、我々は知恵で打ち勝つ。
+NPC_150089,I’m Belia. I teach young Myurans our history and wisdom. Learning never ends.,私はベリア。若いムランたちに我々の歴史と知恵を教えている。学びに終わりはないわ。
+NPC_150090,"If you want to share knowledge with us, you’d better learn our unit system. The YP Law is pretty great, honestly.",知識を私たちと共有したいなら、まず私たちの単位系を学んだほうがいい。YPの法則は、正直かなり優れているのよ。
+NPC_150091,The stars reveal many things. Tonight’s constellations hint at change.,星々は多くを語る。今夜の星座は、変化の兆しを示している。
+NPC_150092,"I’m Kerin. I read the stars for glimpses of the future. Your fate… well, I’m not supposed to say.",私はケリン。星を読んで未来の断片を垣間見ている。あなたの運命は……いえ、それは話せないことになっているの。
+NPC_150093,But I do believe you’re strong enough to face whatever comes.,でも、あなたはどんなことが来ても立ち向かえるだけの強さを持っていると信じているわ。
+NPC_150094,Hunting isn’t just catching prey—it’s understanding nature.,狩りとは、ただ獲物を捕らえることじゃない――自然を理解することだ。
+NPC_150095,"I’m Artin, the village hunter. I bring in fresh meat. Those dogs make it harder lately, but it’s still my job.",私はアーティン、この村の猟師だ。新鮮な肉を届けている。最近はあの犬どものせいでやりにくくなったが、それでも俺の仕事だ。
+NPC_150096,Wanna communicate with mother Nature? Follow me!,母なる自然と語り合いたいか？ついてこい！
+NPC_150097,Trees are alive. I just help shape their lives into new forms.,木々は生きている。私はただ、その命を新しい形に変える手伝いをしているだけだ。
+NPC_150098,I’m Pael. I carve fallen branches from the great town tree. Their memories live through my work.,私はパエル。大樹から落ちた枝を彫っている。その記憶は、私の作品を通して生き続ける。
+NPC_150099,"To speak to living trees, you must use your true name and put your heart into it. I am Pael. I am Pael.",生きた木々と語り合うには、真の名を使い、心を込めなければならない。私はパエル。私はパエルだ。
+NPC_150100,Dreams send messages from within. Understanding them can reveal the truth.,夢は内なる心からのメッセージだ。それを理解すれば、真実が見えてくる。
+NPC_150101,I’m Lumi. I listen to people’s dreams and help them find meaning. Had any strange ones lately?,私はルミ。人々の夢に耳を傾け、その意味を見つける手伝いをしているの。最近、何か不思議な夢は見た？
+NPC_150102,Let me show you… a world of dreams and imagination.,見せてあげる……夢と想像の世界を。
+NPC_150103,The stars hold the stories of our ancestors. Their wisdom still guides us.,星々は先祖たちの物語を宿している。その知恵は今も私たちを導いてくれる。
+NPC_150104,"I’m Ivelyn. I study the constellations. If I learn enough, I might even predict when those dogs will attack.",私はアイヴェリン。星座を研究している。もっと学べば、あの犬どもがいつ襲ってくるかさえ予測できるかもしれないわ。
+NPC_150105,May the ancestors watch over you.,祖先たちがあなたを見守ってくれますように。
+NPC_150106,A scent can hold a memory. One drop of my perfume might bring back something long forgotten.,香りは記憶を宿すことがある。私の香水の一滴が、忘れていた何かを呼び覚ますかもしれない。
+NPC_150107,"I’m Selin, a maker of perfumes. I wonder which scent suits you best.",私はセリン、香水を作っている。どの香りがあなたに一番似合うかしら。
+NPC_150108,The same fragrance smells different on everyone. That’s the magic of it.,同じ香りでも、つける人によって違う匂いになる。それがこの魔法なの。
+NPC_150109,Hey! Don’t tell the adults you saw me here. Seriously—don’t.,ねえ！私をここで見たって大人に言わないでよね。本当に――絶対に言わないで。
+NPC_150110,"I'm Kaela. Go home? Not happening. Wolves or not, I can handle myself.",私はカエラ。家に帰る？冗談じゃないわ。狼がいようがいまいが、自分の身くらい自分で守れるもの。
+NPC_150111,Grown-ups love saying “no.” It’s the one word I can’t stand.,大人はすぐ「だめ」って言うのが好きよね。あの一言だけは我慢できない。
+NPC_150112,Every event carries a lesson. A good story makes it easier to hear.,どんな出来事にも教訓がある。良い物語は、それを聞きやすくしてくれるものだ。
+NPC_150113,I’m Livia. I collect and share our people’s stories. Want to share yours?,私はリビア。私たちの民の物語を集めて語り継いでいる。あなたの物語も聞かせてくれる？
+NPC_150114,Old legends always hide clues—ways to survive today.,古い伝説にはいつも手がかりが隠されている――今日を生き延びるための術がね。
+NPC_150115,"One day… I’ll earn their respect, no matter what it takes.",いつか……何をしてでも、あの人たちの尊敬を勝ち取ってみせる。
+NPC_150116,"I’m Taila. It’s a secret, but I’m actually the jarl’s—…no, I shouldn’t say more.",私はタイラ。秘密なんだけど、実は私、ヤールの……ううん、これ以上は言えないわ。
+NPC_150117,"If I say it out loud, I feel like everything might fall apart. So it stays a secret.",口に出したら、何もかも崩れてしまう気がするの。だから秘密のままにしておくのよ。
+NPC_150118,What are you doing here? Most people don’t even know this place exists.,こんなところで何してるんだ？この場所の存在すら、ほとんどの人は知らないのに。
+NPC_150119,You’re not ready to know the truth. But if you grow stronger… maybe that’ll change.,お前はまだ真実を知る準備ができていない。だが、もっと強くなれば……変わるかもしれない。
+NPC_150120,Turn back. You’re not qualified.,引き返せ。お前にその資格はない。
+NPC_150121,"Where did we go so wrong!? It’s good they aren’t attacking, but still…",一体どこで間違えたんだ！？奴らが襲ってこないのは幸いだが、それにしても……
+NPC_150122,"I'm Beck, from Saint City. I joined the New World Expedition and ended up stuck here. Missed the ship home, sadly.",俺はベック、セイントモーニング出身だ。ニューワールド遠征隊に参加したんだが、結局ここに取り残されちまった。帰りの船に乗り遅れちまってな、悲しいことにさ。
+NPC_150123,People—! A person is here! Help!,誰か――！人がいるぞ！助けてくれ！
+NPC_150124,Keeping watch here isn’t easy. You never know what might creep out of the darkness.,ここの見張りは楽じゃない。闇の中から何が這い出してくるか分からないんだ。
+NPC_150125,Me? I’m the guardian of Ankou’s Asylum. Someone has to make sure the nightmares stay inside.,俺か？俺はベヒモス神殿の守衛だ。悪夢がちゃんと中に留まっているか、誰かが見張らなきゃならないんでね。
+NPC_150126,Feeling brave today? Just remember—I warned you.,今日は勇気があるみたいだな。ただ、警告はしたからな。
+NPC_150127,"If you make it through Ankou’s madness, come find me. I’d love to hear your story… assuming you’re still sane.",もしベヒモスの狂気を乗り越えられたら、俺に会いに来てくれ。お前の話を聞きたいもんだ……その時にまだ正気ならな。
+NPC_DUNGEONBUFF_000001,Earn 2 random Statue Effects (buffs or debuffs).,ランダムな石像効果（バフまたはデバフ）を2つ獲得する。
+NPC_DUNGEONBUFF_000002,Earn 1 Statue Buff (buff only).,石像バフ（バフのみ）を1つ獲得する。
+NPC_DUNGEONBUFF_000003,Change your current statue buff at random.,現在の石像バフをランダムに変更する。
+NPC_150128,Just… leave me alone. I need to rest my eyes.,……ちょっと放っておいてくれ。目を休めたいんだ。
+NPC_150129,I thought I could face him alone… but he was much stronger than I expected. Please be ready if you plan to fight him.,一人で奴に立ち向かえると思ってたんだが……予想よりずっと強かった。戦うつもりなら、覚悟しておいてくれ。
+NPC_150130,Alone… I didn't stand a chance.,一人じゃ……歯が立たなかった。
+NPC_150131,Very well. What do you need?,よかろう。何が必要だ？
+NPC_150132,"Stay vigilant. In wartime, a moment's carelessness can be fatal.",気を抜くな。戦時中は、わずかな油断が命取りになる。
+NPC_150133,Come see me if you're hurt. Proper treatment makes all the difference.,怪我をしたら私のところに来い。適切な治療が何より違いを生む。
+NPC_150134,Safety is my responsibility here. I take that duty seriously.,ここの安全を守るのが私の責任だ。その務めを真剣に果たしている。
+NPC_150135,"This place is quiet, but that doesn't mean we can let our guard down completely.",ここは静かな場所だが、だからといって完全に油断していいわけじゃない。
+NPC_150136,A soldier's watch must never fail. We protect this place with our lives.,兵士の見張りは決して途切れさせてはならない。私たちは命を懸けてこの場所を守っている。
+NPC_150137,I hope your visit brings good fortune to our village.,あなたの訪問が、この村に幸運をもたらしますように。
+NPC_150138,"Pay attention to what you hear. Sometimes the most important information comes when you're listening, not watching.",耳にしたことに気を配れ。時には、見ているときよりも聞いているときのほうが、重要な情報が入ってくるものだ。
+NPC_150139,"The ship left without me, but I can't dwell on that. Life goes on, and so must I.",船は俺を置いて出てしまったが、いつまでも引きずってはいられない。人生は続くし、俺もそうしなきゃな。
+NPC_150140,Quick question—can you handle a task for me?,ちょっと聞きたいんだが――一つ、頼まれてくれないか？
+NPC_150141,I need someone reliable. Think you're up for it?,信頼できる人が必要なんだ。任せられるか？
+NPC_150142,I've got injured people piling up. Could you help me gather some supplies?,怪我人がどんどん増えている。物資を集めるのを手伝ってくれないか？
+NPC_150143,There's something dangerous out there. I need someone to investigate.,外に何か危険なものがいる。調べてくれる人が必要なんだ。
+NPC_150144,Bored of guard duty yet? I've got something more interesting if you're interested.,見張り番に飽きたか？興味があるなら、もっと面白い仕事があるぞ。
+NPC_150145,We've spotted suspicious activity. I need someone to check it out.,怪しい動きを見かけたんだ。調べてくれる人が必要だ。
+NPC_150146,A visitor like you might be able to help with something the locals can't.,お前のような旅人なら、地元の者には手に負えない何かを手伝えるかもしれない。
+NPC_150147,I overheard something important. Want to help me follow up on it?,重要な話を耳にしたんだ。それを追ってくれるのを手伝ってくれないか？
+NPC_150148,"I'm stuck here, but maybe you could help me with something back home?",俺はここに取り残されてるんだが、故郷のことで力を貸してもらえないか？
+NPC_150149,Our supplies are running low. Could you help me gather what we need?,物資が底をつきそうだ。必要なものを集めるのを手伝ってくれないか？
+NPC_150150,That shield you're carrying looks weak. I've got a job that might earn you a better one.,その盾、頼りなさそうだな。もっといいものが手に入る仕事があるぞ。
+NPC_150151,"I've found some interesting gems, but I need help appraising them properly.",面白い宝石を見つけたんだが、きちんと鑑定するのに手を貸してほしい。
+NPC_150152,"There's something I need to tell you… but first, can you help me with a small task?",話したいことがあるんだが……その前に、ちょっとした頼み事を聞いてくれないか？
+NPC_150153,Those Lycans are getting bolder. I need someone to help me track their movements.,ライカンどもが大胆になってきている。奴らの動きを追うのを手伝ってほしい。
+NPC_150154,I'm looking for a real fight. Think you can point me toward something challenging?,本気の戦いを探してるんだ。何か歯応えのあるものを教えてくれないか？
+NPC_150155,I've been working on some new colors. Want to help me test them out?,新しい色をいろいろ試してるんだ。試すのを手伝ってくれない？
+NPC_150156,I've been hearing strange things in people's dreams lately. Can you help me investigate?,最近、人々の夢の中で奇妙なことが起きているらしいの。調べるのを手伝ってくれる？
+NPC_150157,More wounded keep coming in. I could really use some help gathering medical supplies.,負傷者がどんどん運ばれてくる。医療物資を集めるのに、本当に手を貸してほしいの。
+NPC_150158,"I love this village, but there's something I need help protecting.",この村を愛しているけど、守らなきゃいけないものがあるの。手伝ってくれる？
+NPC_150159,The trees have been whispering. They want me to find something. Will you help?,木々がささやいているの。何かを見つけてほしいって。手伝ってくれる？
+NPC_150160,"I've got some powerful magic tools, but I need help testing them safely.",強力な魔法道具を手に入れたんだけど、安全に試すのを手伝ってほしいの。
+NPC_150161,You shouldn't be here. But since you are… maybe you can help me with something.,ここに来るべきじゃなかったのに……まあ、来ちゃったんだし、何か手伝ってもらおうかしら。
+NPC_150162,I've spotted some unusual Lycan movements. Want to help me scout the area?,普段と違うライカンの動きを見つけたの。周辺を偵察するのを手伝ってくれる？
+NPC_150163,I've been fighting for so long. Maybe you can help me finish this once and for all.,もう長いこと戦い続けている。これを終わらせるのを手伝ってくれないか。
+NPC_150164,I've been having strange dreams about you. Want to help me understand what they mean?,最近、あなたについて奇妙な夢を見るの。その意味を理解する手伝いをしてくれる？
+NPC_150165,"I collect stories, and I think yours might be worth hearing. But first, help me with something?",私は物語を集めているんだけど、あなたの話は聞く価値がありそう。でもその前に、何か手伝ってくれる？
+NPC_150166,"Those dogs won't come near us, but something else might. Want to help me keep watch?",あの犬どもは私たちに近づかないけど、他の何かが来るかもしれない。見張りを手伝ってくれる？
+NPC_150167,"I'm on patrol, but I spotted something that needs investigating. Care to join me?",パトロール中に、調べるべきものを見つけたんだ。一緒に来てくれるか？
+NPC_150168,The stars are telling me something important. I need your help to understand it.,星々が重要なことを伝えている。理解するのに、あなたの助けが必要なの。
+NPC_150169,"I've got fresh food ready, but I need help delivering it to some people. Interested?",新鮮な食材の用意はできたんだけど、何人かに届けるのを手伝ってほしいの。興味ある？
+NPC_150170,"Hey, don't tell anyone you saw me, but I could use your help with something.",ねえ、私をここで見たって誰にも言わないでね。でも、ちょっと手を貸してほしいことがあるの。
+NPC_150171,This village has secrets. I might share one if you help me with a task.,この村には秘密があるの。頼み事を聞いてくれたら、一つ教えてあげてもいいわ。
+NPC_150172,"I've been watching the constellations. Something's coming, and I need help preparing.",星座をずっと観察しているの。何かが近づいている――その備えに手を貸してほしいの。
+NPC_150173,I've got injured soldiers who need better armor. Can you help me gather materials?,怪我をした兵士たちにもっと良い防具が必要なんだ。材料を集めるのを手伝ってくれないか？
+NPC_150174,"I thought I could handle it alone, but I was wrong. Can you help me finish what I started?",一人でなんとかできると思ってたが、間違いだった。始めたことを終わらせるのを手伝ってくれないか？
+NPC_150175,"The stars have shown me something about you. Help me, and I'll tell you what I saw.",星があなたについて何かを示したの。手伝ってくれたら、見えたものを教えてあげる。
+NPC_150176,Good armor saves lives. I need help getting materials to make more. Can you assist?,良い防具は命を救う。もっと作るための材料集めに手を貸してほしいの。手伝ってくれる？
+NPC_150177,"I'm loyal to Captain Baron, but there's something I need to handle personally. Will you help?",私はバロン隊長に忠誠を誓っているが、個人的に片づけなければならないことがある。手伝ってくれるか？
+NPC_150178,"I've lived too long in one place. Help me with this, and maybe I can finally move on.",同じ場所に長く住みすぎたわ。これを手伝ってくれたら、ようやく前に進めるかもしれない。
+NPC_150179,"I've been teaching the young ones, but there's something I need to learn myself. Can you help?",若い子たちに教えているけど、私自身も学ばなきゃいけないことがあるの。手伝ってくれる？
+NPC_150180,"I forge weapons, but I need rare materials. Think you can help me find them?",武器を打つ仕事をしているが、希少な素材が要る。見つけるのを手伝ってくれないか？
+NPC_150181,"The village needs protection, and I need someone I can trust. Are you that person?",村には守りが必要で、私には信頼できる誰かが必要だ。お前がその相手か？
+NPC_150182,"I'm an elder, and I've seen many things. Help me with this, and I'll share what I know.",私は長老で、多くのことを見てきた。これを手伝ってくれたら、知っていることを教えよう。
+NPC_150183,The nightmares are getting stronger. I need someone brave enough to help me contain them.,悪夢はどんどん強くなっている。それを封じ込める手伝いをしてくれる、勇気ある人が必要なんだ。
+NPC_150184,Hunting's been tough lately. I could use help tracking down some prey.,最近、狩りがうまくいかなくてね。獲物を追うのを手伝ってくれないか。
+NPC_150185,Security is getting worse every day. I need someone to help me investigate a threat.,治安が日に日に悪化している。脅威を調べるのを手伝ってくれる人が必要だ。
+NPC_150186,Welcome to the #b#cffff0000Eillun Quest Office#nc#nb! Looking for work? I may have a job for you...,#b#cffff0000エルリウン依頼所#nc#nb へようこそ！仕事をお探しですか？あなたにぴったりの仕事があるかもしれません……
 NPC_150187,Welcome to the Quest Office! The local citizens have issued the following quests. Please select the quest you wish to take from the list below.,こんにちは、いくつか依頼があります。以下を選択してください。
 NPC_150188,"My apologies, there are no quests available for an adventurer of your talent and skill at this time. ",ご提供できるクエストがありません。申し訳ありません。またいらしてくださいね。
-NPC_150189,"My name is Miorang and I am the manager of the Eillun Quest Office. When our citizens post a hunting order or another task, it is my job to find the right candidate for the job. Check back in from time to time to see if I have anything available!","My name is Miorang and I am the manager of the Eillun Quest Office. When our citizens post a hunting order or another task, it is my job to find the right candidate for the job. Check back in from time to time to see if I have anything available!"
+NPC_150189,"My name is Miorang and I am the manager of the Eillun Quest Office. When our citizens post a hunting order or another task, it is my job to find the right candidate for the job. Check back in from time to time to see if I have anything available!",私の名前はミオラン、エルリウン依頼所の管理人です。村の住民が討伐依頼やその他の仕事を持ち込むと、それに相応しい人材を見つけるのが私の仕事です。何か空きがないか、時々確認しに来てくださいね！
 NPC_150190,Farewell!,みなさんがんばってください～！
-NPC_150191,Welcome to the #b#cffff0000Office.#nc#nb of Eillun. How can I be of service?,Welcome to the #b#cffff0000Office.#nc#nb of Eillun. How can I be of service?
+NPC_150191,Welcome to the #b#cffff0000Office.#nc#nb of Eillun. How can I be of service?,#b#cffff0000エルリウンの依頼所#nc#nb へようこそ。何かご用でしょうか？
 NPC_150192,"So what can you do for me, huh?",何ができますか？
-NPC_150193,Ugh... maybe next time.,Ugh... maybe next time.
-NPC_150194,My name is Cheirang and I manage the Office of Eillun. How can I help you today?,My name is Cheirang and I manage the Office of Eillun. How can I help you today?
+NPC_150193,Ugh... maybe next time.,うぐ……また今度にするか。
+NPC_150194,My name is Cheirang and I manage the Office of Eillun. How can I help you today?,私の名前はチェイラン、エルリウンの依頼所を管理しています。今日はどのようなご用件でしょうか？
 NPC_150195,Farewell!,みなさんがんばってください～！
-NPC_150196,"Welcome to Eillun! Please, enjoy your stay!","Welcome to Eillun! Please, enjoy your stay!"
+NPC_150196,"Welcome to Eillun! Please, enjoy your stay!",エルリウンへようこそ！どうぞごゆっくりお過ごしください！
 NPC_150197,"Hello, traveler. I have some missions for you!",元気ですか？旅人さん。ミッションを用意しておきますね。
-NPC_150198,"Eillun is the heart of Madrigal’s blooming spirit. Our trees may tower over the skies, but our hospitality always reaches further. Should you ever seek guidance, come find me beneath the Great Blossom.","Eillun is the heart of Madrigal’s blooming spirit. Our trees may tower over the skies, but our hospitality always reaches further. Should you ever seek guidance, come find me beneath the Great Blossom."
-NPC_150199,I am the mayor of Eillun. The harmony of our blossoms and our people is what I cherish most. How may I assist you today beneath our great trees?,I am the mayor of Eillun. The harmony of our blossoms and our people is what I cherish most. How may I assist you today beneath our great trees?
+NPC_150198,"Eillun is the heart of Madrigal’s blooming spirit. Our trees may tower over the skies, but our hospitality always reaches further. Should you ever seek guidance, come find me beneath the Great Blossom.",エルリウンは、マドリガルに息づく繁栄の心臓部です。私たちの木々は空高くそびえ立ちますが、もてなしの心はさらに遠くまで届きます。導きが必要になったら、大いなる花の下で私を訪ねてください。
+NPC_150199,I am the mayor of Eillun. The harmony of our blossoms and our people is what I cherish most. How may I assist you today beneath our great trees?,私はエルリウンの族長です。花々と民の調和こそ、私が最も大切にしているものです。この大樹の下で、今日はどのようなご用件でしょうか？
 NPC_150200,Farewell!,みなさんがんばってください～！
-NPC_150201,I've spotted a security issue that needs immediate attention. Can you handle it?,I've spotted a security issue that needs immediate attention. Can you handle it?
-NPC_100198,Let luck do its thing.,Let luck do its thing.
-NPC_100199,I deal in pieces and fortune.\nCare to try your luck?,I deal in pieces and fortune.\nCare to try your luck?
-NPC_100200,Wanna test your luck?,Wanna test your luck?
-NPC_150202,#b#cff8a004fThe #cfff60000Level 165 Guild Siege Application Center #cff8a004fis open! Enjoy it before your third class!#nc#nb,#b#cff8a004fThe #cfff60000Level 165 Guild Siege Application Center #cff8a004fis open! Enjoy it before your third class!#nc#nb
-NPC_150203,Good Luck!,Good Luck!
-NPC_155001,The fields are still in trouble. Stay sharp—whatever's in there isn't done yet.,The fields are still in trouble. Stay sharp—whatever's in there isn't done yet.
-NPC_155002,"O-oh! You're from the guard, r-right? I-I swear, it's not just bad farming! The mushrooms just… changed. S-something's not right, I'm telling you…","O-oh! You're from the guard, r-right? I-I swear, it's not just bad farming! The mushrooms just… changed. S-something's not right, I'm telling you…"
-NPC_155003,"So the guard finally noticed, huh. Took you long enough. If you want answers, you'd better be ready to hear them.","So the guard finally noticed, huh. Took you long enough. If you want answers, you'd better be ready to hear them."
-NPC_155004,"Fascinating, isn't it? The crops here aren't simply rotting—they're changing. Now that you're here, we should report this immediately.","Fascinating, isn't it? The crops here aren't simply rotting—they're changing. Now that you're here, we should report this immediately."
-NPC_155010,"P-Please help! The plants here... they're moving, they're alive!","P-Please help! The plants here... they're moving, they're alive!"
-NPC_155011,"I'm Sprout. I used to work on this farm... well, I guess it WAS a farm...","I'm Sprout. I used to work on this farm... well, I guess it WAS a farm..."
-NPC_155012,Please save me... I just want to get out of here...,Please save me... I just want to get out of here...
-NPC_155013,"Tch, those damn Lycan... If I get out of here alive, they'll pay...!","Tch, those damn Lycan... If I get out of here alive, they'll pay...!"
-NPC_155014,"Name's Thorn. This wasn't exactly the thing to shed blood... but now it's gotten real interesting, hasn't it.","Name's Thorn. This wasn't exactly the thing to shed blood... but now it's gotten real interesting, hasn't it."
-NPC_155015,"Damn it, there are still people trapped inside!","Damn it, there are still people trapped inside!"
-NPC_155016,You're the rescue team? Good. You'll need my observation records.,You're the rescue team? Good. You'll need my observation records.
-NPC_155017,"I'm Root. I was in charge of plant mutation management and cultivation... Well, I WAS. Now I'm investigating this incident.","I'm Root. I was in charge of plant mutation management and cultivation... Well, I WAS. Now I'm investigating this incident."
-NPC_155018,Hmm... I should document that mutation pattern...,Hmm... I should document that mutation pattern...
-NPC_155019,"This is serious… For something like this to happen inside the village…\nWe need to contain it, and fast.","This is serious… For something like this to happen inside the village…\nWe need to contain it, and fast."
-NPC_155020,Baron here. Have you found the three yet?,Baron here. Have you found the three yet?
-NPC_155021,We don’t have much time. Every delay makes things worse.,We don’t have much time. Every delay makes things worse.
-NPC_156000,P-please help me! I-I can't go back to the village like this! W-what if those things show up again? I-I won't make it on my own...,P-please help me! I-I can't go back to the village like this! W-what if those things show up again? I-I won't make it on my own...
-NPC_156001,"W-wait... you're leaving me here?! P-please, I'm begging you... I can't do this alone...","W-wait... you're leaving me here?! P-please, I'm begging you... I can't do this alone..."
-NPC_156002,Y-you did it! Th-thank you so much! I... I don't know what I would have done without you. Th-thank you...,Y-you did it! Th-thank you so much! I... I don't know what I would have done without you. Th-thank you...
-NPC_156003,You. Good. Something out there is watching us... I'm not letting it compromise this operation. Stay sharp and stay close to me.,You. Good. Something out there is watching us... I'm not letting it compromise this operation. Stay sharp and stay close to me.
-NPC_156004,"Coward! Without your help, how am I supposed to protect anyone out there? This is unacceptable!","Coward! Without your help, how am I supposed to protect anyone out there? This is unacceptable!"
-NPC_156005,Well done. You've proven your worth. That's the kind of strength we need. My thanks... and respect.,Well done. You've proven your worth. That's the kind of strength we need. My thanks... and respect.
-NPC_156006,...This is unexpected. Something beneath the soil is actively reacting to your presence. I need time to observe it. The data could be critical.,...This is unexpected. Something beneath the soil is actively reacting to your presence. I need time to observe it. The data could be critical.
-NPC_156007,"Don't slow down. If those creatures interrupt my readings, everything is compromised. I can't afford another setback.","Don't slow down. If those creatures interrupt my readings, everything is compromised. I can't afford another setback."
-NPC_156008,The readings are clear now. Your protection allowed me to gather the information we needed. Excellent work. This changes everything.,The readings are clear now. Your protection allowed me to gather the information we needed. Excellent work. This changes everything.
-NPC_156009,"Like I said, we should not stay here any longer. The activity beneath the soil is escalating faster than expected. We need to relocate now.","Like I said, we should not stay here any longer. The activity beneath the soil is escalating faster than expected. We need to relocate now."
-NPC_156010,Don't abandon me out here. The creatures are reacting to what I'm carrying. I need your cover to escape safely.,Don't abandon me out here. The creatures are reacting to what I'm carrying. I need your cover to escape safely.
-NPC_156011,You made it out. Good. The data is secure and the specimens are intact. This expedition was a success. My gratitude.,You made it out. Good. The data is secure and the specimens are intact. This expedition was a success. My gratitude.
-NPC_156012,Hehe~ Feeling brave? I can send you right back in to test yourself against Entaness again.,Hehe~ Feeling brave? I can send you right back in to test yourself against Entaness again.
-NPC_156013,Oh... alright. Come find me whenever you feel ready.,Oh... alright. Come find me whenever you feel ready.
-NPC_156014,I'm Musha. I keep watch over this place and guide adventurers who want another shot at Entaness.,I'm Musha. I keep watch over this place and guide adventurers who want another shot at Entaness.
+NPC_150201,I've spotted a security issue that needs immediate attention. Can you handle it?,すぐに対応が必要な治安問題を見つけたんだ。対処してくれるか？
+NPC_100198,Let luck do its thing.,運を天に任せよう。
+NPC_100199,I deal in pieces and fortune.\nCare to try your luck?,運試しと財運を扱っているんだ。\n運試ししてみるかい？
+NPC_100200,Wanna test your luck?,運試ししてみる？
+NPC_150202,#b#cff8a004fThe #cfff60000Level 165 Guild Siege Application Center #cff8a004fis open! Enjoy it before your third class!#nc#nb,#b#cff8a004f#cfff60000Lv165ギルドコンバット申込センター#cff8a004fが開設中です！3次職になる前にぜひご利用ください！#nc#nb
+NPC_150203,Good Luck!,幸運を！
+NPC_155001,The fields are still in trouble. Stay sharp—whatever's in there isn't done yet.,畑はまだ厄介な状態だ。油断するな――中にいる何かは、まだ終わっていない。
+NPC_155002,"O-oh! You're from the guard, r-right? I-I swear, it's not just bad farming! The mushrooms just… changed. S-something's not right, I'm telling you…",お、おお！衛兵さんだよな、そ、そうだろ？い、いや、ただの不作じゃないんだ！キノコが……ただ、変わっちまったんだよ。な、何かがおかしいんだ……
+NPC_155003,"So the guard finally noticed, huh. Took you long enough. If you want answers, you'd better be ready to hear them.",ようやく衛兵が気づいたか。遅すぎるくらいだけどな。答えが欲しいなら、覚悟して聞くんだな。
+NPC_155004,"Fascinating, isn't it? The crops here aren't simply rotting—they're changing. Now that you're here, we should report this immediately.",興味深いだろう？ここの作物はただ腐っているんじゃない――変化しているんだ。お前が来たからには、すぐに報告すべきだな。
+NPC_155010,"P-Please help! The plants here... they're moving, they're alive!",た、助けて！ここの植物が……動いてる、生きてるんだ！
+NPC_155011,"I'm Sprout. I used to work on this farm... well, I guess it WAS a farm...",俺はスプラウト。この農場で働いてたんだ……いや、もう〝農場だった〟って言うべきかな……
+NPC_155012,Please save me... I just want to get out of here...,頼む、助けてくれ……ここから出たいだけなんだ……
+NPC_155013,"Tch, those damn Lycan... If I get out of here alive, they'll pay...!",ちっ、あのクソったれなライカンども……生きてここを出られたら、必ず償わせてやる……！
+NPC_155014,"Name's Thorn. This wasn't exactly the thing to shed blood... but now it's gotten real interesting, hasn't it.",名前はソーン。もとはこんな血まみれになる予定じゃなかったんだが……いや、こうなるとかえって面白くなってきたな。
+NPC_155015,"Damn it, there are still people trapped inside!",くそっ、まだ中に閉じ込められてる奴らがいるんだ！
+NPC_155016,You're the rescue team? Good. You'll need my observation records.,お前が救助隊か？よし。俺の観察記録が必要になるはずだ。
+NPC_155017,"I'm Root. I was in charge of plant mutation management and cultivation... Well, I WAS. Now I'm investigating this incident.",私はルート。植物の変異管理と栽培を担当していた……いや、〝していた〟だな。今はこの事件を調査している。
+NPC_155018,Hmm... I should document that mutation pattern...,ふむ……あの変異パターンは記録しておくべきだな……
+NPC_155019,"This is serious… For something like this to happen inside the village…\nWe need to contain it, and fast.",これは深刻だ……こんなことが村の中で起きるとはな……\n早急に封じ込めなければならない。
+NPC_155020,Baron here. Have you found the three yet?,バロンだ。三人はもう見つかったか？
+NPC_155021,We don’t have much time. Every delay makes things worse.,時間がない。遅れるほど事態は悪化する。
+NPC_156000,P-please help me! I-I can't go back to the village like this! W-what if those things show up again? I-I won't make it on my own...,た、助けてくれ！こ、こんな姿で村には戻れない！も、もしまたあれが現れたら？お、俺一人じゃ無理だ……
+NPC_156001,"W-wait... you're leaving me here?! P-please, I'm begging you... I can't do this alone...",ま、待てよ……お、俺をここに置いていくのか！？た、頼む、一人じゃ無理なんだ……
+NPC_156002,Y-you did it! Th-thank you so much! I... I don't know what I would have done without you. Th-thank you...,や、やったな！あ、ありがとう！お前がいなかったら、俺はどうなってたか……本当にありがとう……
+NPC_156003,You. Good. Something out there is watching us... I'm not letting it compromise this operation. Stay sharp and stay close to me.,お前か。よし。外で何かがこっちを見てる……この作戦を邪魔させはしない。気を抜くな、俺のそばを離れるなよ。
+NPC_156004,"Coward! Without your help, how am I supposed to protect anyone out there? This is unacceptable!",腰抜けが！お前の助けなしで、どうやって誰かを守れって言うんだ！冗談じゃない！
+NPC_156005,Well done. You've proven your worth. That's the kind of strength we need. My thanks... and respect.,よくやった。お前の実力は本物だ。俺たちに必要なのはそういう強さだよ。感謝する……そして、認めよう。
+NPC_156006,...This is unexpected. Something beneath the soil is actively reacting to your presence. I need time to observe it. The data could be critical.,……これは予想外だ。土の下の何かが、お前の存在に明らかに反応している。観察する時間が要る。このデータは重要かもしれない。
+NPC_156007,"Don't slow down. If those creatures interrupt my readings, everything is compromised. I can't afford another setback.",手を緩めるな。あの生物どもに観測を邪魔されたら、すべてが台無しになる。もう後がないんだ。
+NPC_156008,The readings are clear now. Your protection allowed me to gather the information we needed. Excellent work. This changes everything.,測定結果がはっきりしたぞ。お前が守ってくれたおかげで、必要なデータを集められた。見事な働きだ。これで状況が変わる。
+NPC_156009,"Like I said, we should not stay here any longer. The activity beneath the soil is escalating faster than expected. We need to relocate now.",言った通りだ、これ以上ここに留まるべきじゃない。土の下の活動は予想以上の速さで悪化している。今すぐ移動する必要がある。
+NPC_156010,Don't abandon me out here. The creatures are reacting to what I'm carrying. I need your cover to escape safely.,俺を置き去りにしないでくれ。あの生物どもは、俺が持っているものに反応しているんだ。無事に逃げるには、お前の護衛が要る。
+NPC_156011,You made it out. Good. The data is secure and the specimens are intact. This expedition was a success. My gratitude.,よく生き延びたな。データは無事、標本も無傷だ。この遠征は成功だった。感謝する。
+NPC_156012,Hehe~ Feeling brave? I can send you right back in to test yourself against Entaness again.,へへ～勇気があるじゃない？もう一度エンタネスに挑ませてあげてもいいわよ。
+NPC_156013,Oh... alright. Come find me whenever you feel ready.,あら……分かったわ。準備ができたら、いつでも私を訪ねてきて。
+NPC_156014,I'm Musha. I keep watch over this place and guide adventurers who want another shot at Entaness.,私はムシャ。この場所を見張って、もう一度エンタネスに挑みたい冒険者を案内しているの。

--- a/Japanese/TextClient.csv
+++ b/Japanese/TextClient.csv
@@ -1573,4 +1573,4 @@ TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD,You received a reward for clearing a new 
 TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD_MAIL,You can't receive the reward for clearing a new floor. Check your mail.,You can't receive the reward for clearing a new floor. Check your mail.
 TEXTCLIENT_MYSTCASTLE_USE_FLOOR_TICKET_FAIL,Unable to use the Mysterious Castle Retry Coupon.,Unable to use the Mysterious Castle Retry Coupon.
 TEXTCLIENT_LORDSKILLS_NOT,Only the Lord can use this menu.,Only the Lord can use this menu.
-TEXTCLIENT_DUNGEON_ESCORT_DIED,Your escort died.,Your escort died.
+TEXTCLIENT_DUNGEON_ESCORT_DIED,Your escort died.,護衛対象が死亡しました。

--- a/Japanese/TextClient.csv
+++ b/Japanese/TextClient.csv
@@ -37,9 +37,9 @@ TEXTCLIENT_SECS,second(s),秒
 TEXTCLIENT_MINS,minute(s),分
 TEXTCLIENT_HOURS,hour(s),時間
 TEXTCLIENT_SESSIONEXPIRED,"Your session has expired, please enter your login and password again.",セッションの有効期限が切れています。再度パスワードを入力してログインしてください。
-TEXTCLIENT_ADMIN,Admin,Admin
+TEXTCLIENT_ADMIN,Admin,管理者
 TEXTCLIENT_DEVELOPER,Dev,開発者
-TEXTCLIENT_GAMEMASTER,Game Master,Game Master
+TEXTCLIENT_GAMEMASTER,Game Master,ゲームマスター
 TEXTCLIENT_MODERATOR,MOD,MOD
 TEXTCLIENT_VENDOR_NPC,[Vendor],[売り子]
 TEXTCLIENT_APP_CHAT,Chat Window,チャット
@@ -91,7 +91,7 @@ TEXTCLIENT_ERROR_SEX,%s is not for your gender.,%sを使うには、性別が合
 TEXTCLIENT_ERROR_JOB,You cannot equip the %s. Requirements not met.,装備条件に満たしていないため、%sを装備することができません。
 TEXTCLIENT_ERROR_LEVEL,You cannot equip this item because your level is too low. (Req Lev: %d),キャラクターレベルが低いため、装備できません。（必要レベル：%d）
 TEXTCLIENT_ERROR_UNDESTRUCTABLE,You can not discard this item.,削除したり、地面に置くことができないアイテムです。
-TEXTCLIENT_ERROR_USINGITEM,You are already using this item.,You are already using this item.
+TEXTCLIENT_ERROR_USINGITEM,You are already using this item.,このアイテムは既に使用中です。
 TEXTCLIENT_SUCCESSREMOVEITEM,Number of %s deleted: %d.,「%s」を%d個削除しました。
 TEXTCLIENT_NOTARGET,"Cannot attack, no monster targeted.",ターゲットしていないか、モンスターではないため使用できません。
 TEXTCLIENT_NOTUSE,You cannot use this yet.,まだご利用できません。
@@ -124,9 +124,9 @@ TEXTCLIENT_COMMUNITY,Community,コミュニティ
 TEXTCLIENT_HELPER,Helper,ヘルパー
 TEXTCLIENT_APP_ITEM_DURATION,Duration,期限
 TEXTCLIENT_APP_MESSENGER,Messenger,メッセンジャー
-TEXTCLIENT_APP_PARTY,Party,Party
+TEXTCLIENT_APP_PARTY,Party,パーティー
 TEXTCLIENT_APP_GUILD,Guild,ギルド
-TEXTCLIENT_APP_COUPLE,Couple,Couple
+TEXTCLIENT_APP_COUPLE,Couple,カップル
 TEXTCLIENT_APP_HELP,Help,ヘルプ
 TEXTCLIENT_APP_HELP_TIPS,Tips,簡単なTips集
 TEXTCLIENT_APP_FAQ,FAQ,FAQ
@@ -301,10 +301,10 @@ TEXTCLIENT_COMACCEPTWELCOME,%s has joined the guild.,ギルドに %s が加入�
 TEXTCLIENT_GUILDNOTHINGNAME,Unable to make a contribution. Ask your Guild Leader to set the guild name first.,ギルド名が設定されていないため献上できません。ギルドマスターはギルド名を設定してください。
 TEXTCLIENT_GUILDMERITMAXLEVEL,Unable to make a contribution. The guild has reached its maximum level.,ギルドレベルが満たないため、献上できません。
 TEXTCLIENT_GUILDLEVELUP,Guild level has increased.,ギルドレベルがアップしました。
-TEXTCLIENT_GUILDCLOAK,%s Guild Cloak,%s Guild Cloak
+TEXTCLIENT_GUILDCLOAK,%s Guild Cloak,%sギルドクローク
 TEXTCLIENT_NOTTRADE,You cannot trade a premium item.,このプレミアムアイテムはギルド倉庫に保管することができません
 TEXTCLIENT_GUILDBANKFULL,The guild warehouse is full.,ギルド倉庫に空きがありません。
-TEXTCLIENT_COUPLEBANKFULL,The couple storage is full.,The couple storage is full.
+TEXTCLIENT_COUPLEBANKFULL,The couple storage is full.,カップル倉庫がいっぱいです。
 TEXTCLIENT_SLOTFULL,Your inventory is full.,空きがありません。
 TEXTCLIENT_CONFIRMMOVEITEM,Really move this item?,本当に移動してよろしいですか？
 TEXTCLIENT_GUILDCREATECLOAK,Guild cloak has been created.,ギルドマントを作成しました。
@@ -317,16 +317,16 @@ TEXTCLIENT_CHOICEJOB,You have to choose a job at Lv 15.,レベル15以上は転�
 TEXTCLIENT_ERROR_NOTEXPERTJOB,Not Expert Job,エキスパートではない職業
 TEXTCLIENT_EXPERTJOBS,Expert Job: %s,エキスパート職業: %s
 TEXTCLIENT_EXPERTLEVEL,Expert Level: %d ~ %d,エキスパートレベル: %d ~ %d
-TEXTCLIENT_ERROR_NOTPROFESSIONALJOB,Not Professional Job,プロではない職業
-TEXTCLIENT_ERROR_NOTSPECIALISTJOB,Not Specialist Job,Not Specialist Job
-TEXTCLIENT_PROFESSIONALJOBS,Professional Job: %s,プロな職業: %s
+TEXTCLIENT_ERROR_NOTPROFESSIONALJOB,Not Professional Job,プロフェッショナルではない職業
+TEXTCLIENT_ERROR_NOTSPECIALISTJOB,Not Specialist Job,スペシャリストではない職業
+TEXTCLIENT_PROFESSIONALJOBS,Professional Job: %s,プロフェッショナル職業: %s
 TEXTCLIENT_PROFESSIONALLEVEL,Professional Level: %d ~~~,プロレベル: %d ~~~
-TEXTCLIENT_SPECIALISTJOBS,Specialist Job: %s,Specialist Job: %s
-TEXTCLIENT_SPECIALISTLEVEL,Specialist Level: %d ~~~,Specialist Level: %d ~~~
+TEXTCLIENT_SPECIALISTJOBS,Specialist Job: %s,スペシャリスト職：%s
+TEXTCLIENT_SPECIALISTLEVEL,Specialist Level: %d ~~~,スペシャリストレベル：%d ~~~
 TEXTCLIENT_SKILLPOINT_UP,New Skill Points are now available.,スキルポイント上昇!!
 TEXTCLIENT_REAPSKILL,You've learned %s. You can now allocate skill points to this ability.,%s を習得しました。スキルポイントを割り当てることができるようになりました。
 TEXTCLIENT_FLYLVLUP,Flying level up!,飛行レベルがアップしました。
-TEXTCLIENT_NEEDSATTACKITEM,You must equip either Arrows or the appropriate Poster or Vial to use this skill.,You must equip either Arrows or the appropriate Poster or Vial to use this skill.
+TEXTCLIENT_NEEDSATTACKITEM,You must equip either Arrows or the appropriate Poster or Vial to use this skill.,このスキルを使用するには、矢または該当するポスターかバイアルを装備する必要があります。
 TEXTCLIENT_BOSS_BIGMUSCLE_MSG1,How dare you come here!,貴様ら、ここが何処か知ってるのか！
 TEXTCLIENT_BOSS_BIGMUSCLE_MSG2,You have no fear!,死を恐れるとは愚かな奴らだ！
 TEXTCLIENT_BOSS_BIGMUSCLE_MSG3,I will be your executioner!,俺様が、お前らに裁きを下してやる！
@@ -343,12 +343,12 @@ TEXTCLIENT_REQ_DARK,You are not in Dark Illusion mode.,ダークイリュージ�
 TEXTCLIENT_NEVERKILLSTOP,You cannot use the skill.,スキルが使えません。
 TEXTCLIENT_NOTELEMWEAPON,Unable to use equipped item. Item needs an elemental upgrade first.,装備中の武器に属性が付与されていないため使用できません。
 TEXTCLIENT_DONOTUSEBUFF,Cannot use the skill at this time.,上級レベルのスキルを使用中には、このスキルは使えません。
-TEXTCLIENT_NEEDSKILLITEM,You must equip either Arrows or the appropriate Poster or Vial to use this skill.,You must equip either Arrows or the appropriate Poster or Vial to use this skill.
+TEXTCLIENT_NEEDSKILLITEM,You must equip either Arrows or the appropriate Poster or Vial to use this skill.,このスキルを使用するには、矢または該当するポスターかバイアルを装備する必要があります。
 TEXTCLIENT_SKILLWAITTIME,Please wait.,しばらくお待ちください。
 TEXTCLIENT_SKILL_SELF,You use %s.,%sを使用しました
-TEXTCLIENT_SKILL_SELF_INHERITED,You use %s (%s).,You use %s (%s).
+TEXTCLIENT_SKILL_SELF_INHERITED,You use %s (%s).,%s（%s）を使用しました。
 TEXTCLIENT_SKILL_MATE,%s casts %s on you.,%s が %s を使用しました。
-TEXTCLIENT_SKILL_MATE_INHERITED,%s casts %s (%s) on you.,%s casts %s (%s) on you.
+TEXTCLIENT_SKILL_MATE_INHERITED,%s casts %s (%s) on you.,%sがあなたに%s（%s）を使用しました。
 TEXTCLIENT_EQUIP_DENIAL,Permission to view equipment denied.,装備確認を拒絶しています。
 TEXTCLIENT_OPTIONREBOOT,You must restart the game for all changes to take effect.,すべての変更を有効にするには、ゲームを再起動する必要があります。
 TEXTCLIENT_LIMITED_USE,You are already using this item. Try again after its effects have worn off.,現在使用中の同じアイテムは使用できません。持続時間が終了するまでお待ちください。
@@ -385,7 +385,7 @@ TEXTCLIENT_CREATEMON_CANCEL,Monster invocation was cancelled.,モンスター召
 TEXTCLIENT_USEAIRCRAFT,"In order to ride a flying vehicle, you must reach level 20.",レベル20未満のキャラクターは使用できません。
 TEXTCLIENT_QUEST_DISGUISE_NOTFLY,You cannot fly while transforming.,変身中は飛ぶことができません。
 TEXTCLIENT_UPGRADE_FIRE,Fire,火
-TEXTCLIENT_UPGRADE_WATER,Water,Water
+TEXTCLIENT_UPGRADE_WATER,Water,水
 TEXTCLIENT_UPGRADE_ELECTRICITY,Electric,雷
 TEXTCLIENT_UPGRADE_WIND,Wind,風
 TEXTCLIENT_UPGRADE_EARTH,Earth,土
@@ -416,7 +416,7 @@ TEXTCLIENT_COLLECT_ERROROTHER,Unable to collect resource from a monster killed b
 TEXTCLIENT_HARVEST_EQUIP,You need to equip harvesting gloves.,収穫用手袋を装備する必要があります。
 TEXTCLIENT_HARVEST_RECEIVE,You have harvested %s x%d.,%sx%dを収穫しました。
 TEXTCLIENT_HARVEST_CARRIER,A harvest carrier has been revealed! Kill it to gain its extra berries.,収穫キャリアが明らかになりました！それらを倒して余分なベリーを手に入れましょう。
-TEXTCLIENT_HARVEST_COOLDOWN,"You cannot currently open it, try again in a few seconds.","You cannot currently open it, try again in a few seconds."
+TEXTCLIENT_HARVEST_COOLDOWN,"You cannot currently open it, try again in a few seconds.",現在開くことができません。数秒後にもう一度お試しください。
 TEXTCLIENT_NOTREADY_USESHOP,Please try again after taking off the head item,頭に装備しているアイテムを外してから、利用してください。
 TEXTCLIENT_SHOP_CHOICE,Selected,選択した
 TEXTCLIENT_CHANGE_HAIR,Change your Hair,選択したヘアーチェンジの費用は
@@ -626,7 +626,7 @@ TEXTCLIENT_GUILDCOMBAT_EXPENSE_RETURN,The application fee has been refunded.,ギ
 TEXTCLIENT_GUILDCOMBAT_CANCEL,Your guild's application for the Guild Siege has been canceled.,ギルドコンバット申請をキャンセルしました。
 TEXTCLIENT_GC_CANCELREQUEST,Guild Siege Application Refund,[GCC]キャンセルによる払戻し
 TEXTCLIENT_GC_CANCELREQUEST1,"Hello, this is [Guild Siege Manager] Donaris.\nYour Guild Siege application has been canceled, and the application fee has been refunded. Please note that a 20% commission has been deducted.\nHave a nice day!",こんにちは。私はドナリスというギルドマネージャーです。\nキャンセルされたので返却させていただきますが、手数料として20％を差し引いています。\n良い一日を！
-TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT,Today's Guild Siege will not be held due to lack of participants.,Today's Guild Siege will not be held due to lack of participants.
+TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT,Today's Guild Siege will not be held due to lack of participants.,本日のギルドコンバットは、参加者不足のため開催されません。
 TEXTCLIENT_GUILDCOMBAT_ENJOY,Have a good day!,よい空の旅を！
 TEXTCLIENT_GUILDCOMBAT_JOIN_OK,You have qualified to enter the Guild Siege. Please complete your lineup setup in Flarine.,ギルドコンバットの参加資格を得ました。フラリスで「ギルド攻城戦への布陣」を今すぐ終わらせてください。
 TEXTCLIENT_GUILDCOMBAT_JOIN_CANCEL,"You did not qualify for this Guild Siege. Please try again next week. After the Guild Siege ends, you may reclaim the application fee in Flarine.",ギルドコンバットの参加資格を得られませんでした。またチャレンジしてください。払戻し金は、ファン・ギフトにてお送りします。
@@ -651,7 +651,7 @@ TEXTCLIENT_GUILDCOMBAT_ENTER,The Guild Siege is now open.,今週のギルドコ�
 TEXTCLIENT_GUILDCOMBAT_NOT_JOIN,Please join after a while.,入場開始まで少々お待ちください。
 TEXTCLIENT_GUILDCOMBAT_NOT_OPEN,Preparations underway.,準備中です。
 TEXTCLIENT_GUILDCOMBAT_NOTENTER_VAGRANT,Vagrants are not eligible for the Guild Siege. Please try again after your first job change.,放浪者は入場できません。1次転職をしていることが条件です。
-TEXTCLIENT_GUILDCOMBAT_NOTENTER_SPECIALIST,A character with third class is not eligible for Lv165 guild siege.,A character with third class is not eligible for Lv165 guild siege.
+TEXTCLIENT_GUILDCOMBAT_NOTENTER_SPECIALIST,A character with third class is not eligible for Lv165 guild siege.,3次職のキャラクターはLv165ギルドコンバットに参加できません。
 TEXTCLIENT_GUILDCOMBAT_WELCOME,Welcome to the Guild Siege.,ギルドコンバットにようこそ！
 TEXTCLIENT_GUILDCOMBAT_ZOOM_USE,You can zoom the camera using the [Scroll Lock] key.,[Scroll Lock]キーを押すと、段階別のカメラ拡大になります。
 TEXTCLIENT_GUILDCOMBAT_JOIN_MSG_MASTER,You are the Guild Master! Defeating the Defender grants 1 bonus point.,あなたはギルドマスターです！ディフェンダーを倒すとボーナスがもらえます。
@@ -663,7 +663,7 @@ TEXTCLIENT_GUILDCOMBAT_WAR,Start Combat,コンバットスタート
 TEXTCLIENT_GUILDCOMBAT_POINT_MASTER,The Guild Master has gained %d points!,ギルドマスターは%dを獲得しました！
 TEXTCLIENT_GUILDCOMBAT_POINT_GENERAL,Your guild has gained %d points!,あなたのギルドが%dポイントを獲得！
 TEXTCLIENT_GUILDCOMBAT_POINT_DEFENDER,Your defender is dead! %s guild has gained an extra point!,味方のディフェンダーが死亡！「%s」ギルドがポイントを獲得！！
-TEXTCLIENT_GUILDCOMBAT_POINT_REVIVAL,You gained %d resurrection points!,You gained %d resurrection points!
+TEXTCLIENT_GUILDCOMBAT_POINT_REVIVAL,You gained %d resurrection points!,復活ポイントを%d獲得しました！
 TEXTCLIENT_GUILDCOMBAT_WRONG_CHANNEL,You must be connected on Channel 1 to enter the Guild Siege.,ギルドコンバットへ入場するにはチャンネル1に接続している必要があります。
 TEXTCLIENT_GUILDCOMBAT_END,The Guild Siege has ended.,ギルドコンバットが終了しました。
 TEXTCLIENT_GUILDCOMBAT_WINNER,This week's winning guild: %s.,今週最強の王者は、ギルド%s！！おめでとう！
@@ -708,7 +708,7 @@ TEXTCLIENT_DISCONNECTED_HACK,Your character has been banned because the system d
 TEXTCLIENT_CASHMAP_MAPITEMUSE,"If you use the torch, you will be able to see this map. Continue?",トーチを使えば、このエリアの地図を見ることができます。使用しますか？
 TEXTCLIENT_PET_NOWUSE,You already have a pet summoned.,既に召喚中のペットがいます。
 TEXTCLIENT_CHAOTIC_NO_FLY,A character with a bad Disposition cannot fly.,カオスユーザーは飛行できません。
-TEXTCLIENT_SERVERTEST,[Notice] This is a test! Server will close in %s and characters will be deleted.,[Notice] This is a test! Server will close in %s and characters will be deleted.
+TEXTCLIENT_SERVERTEST,[Notice] This is a test! Server will close in %s and characters will be deleted.,[お知らせ]これはテストです！サーバーは%s後に終了し、キャラクターは削除されます。
 TEXTCLIENT_EARLY_ACCESS,[Notice] This is the Early Access! Server stability issues and bugs can occur.,【お知らせ】早期アクセスです！サーバーの安定性の問題とバグが発生する可能性があります。
 TEXTCLIENT_ALERT_NO_PK,[Notice] A GM (Game Master) will never ask for your Account or Bank Password.,【注意】GM（ゲームマスター）がアカウントや銀行のパスワードを聞くことは絶対にありません。
 TEXTCLIENT_ALERT_PK,[Notice] Do not lend or let a player borrow your items. If they do not give the item back it is lost forever.,【注意】アイテムの貸し借りはしないでください。成立したトレードは元に戻せません。詐欺にご注意ください。
@@ -800,7 +800,7 @@ TEXTCLIENT_UPGRADEANNOUNCE_BOUND,%s upgraded [Soul-Bound] %s to %s+%d!,%s が[�
 TEXTCLIENT_LEVELUPANNOUNCE,%s reached level %d!,%sがレベル%dに達しました！
 TEXTCLIENT_APP_GACHA,Gacha,ガチャ
 TEXTCLIENT_GACHA_RESET_SUCCESS,The box has been successfully reset.,ボックスは正常にリセットされました。
-TEXTCLIENT_APP_BOT,Bot,Bot
+TEXTCLIENT_APP_BOT,Bot,ボット
 TEXTCLIENT_SKILL_AWAKE,Item received a bonus.,アイテムボーナスを受け取りました。
 TEXTCLIENT_SKILL_AWAKE_FAILED,No bonus is available for this item.,このアイテムにはボーナスはありません。
 TEXTCLIENT_INVALID_TARGET_ITEM,Cannot be done.,できませんでした。
@@ -879,20 +879,20 @@ TEXTCLIENT_ADDWARDROBE,The item has been added to your wardrobe.,アイテムが
 TEXTCLIENT_GUILDWARCHANNEL,Unable to declare war in this channel.,このチャンネルでは宣戦布告できません。
 TEXTCLIENT_APP_BATTLEPASS,Flyff Pass,バトルパス
 TEXTCLIENT_BATTLEPASS_MISSIONCOMPLETE,%s mission %s completed.,%s ミッション %s が完了しました。
-TEXTCLIENT_BATTLEPASS_GETPOINTS,You received %d %s points.,You received %d %s points.
+TEXTCLIENT_BATTLEPASS_GETPOINTS,You received %d %s points.,%d %sポイントを獲得しました。
 TEXTCLIENT_BATTLEPASS_RESET,The %s season has been reset!,%s シーズンがリセットされました!
 TEXTCLIENT_BATTLEPASS_NEWRANK,You reached the %s grade %d!,%s のグレード %d に達しました!
-TEXTCLIENT_BATTLEPASS_NEWBONUSRANK,You reached the %s bonus grade %d+%d!,You reached the %s bonus grade %d+%d!
+TEXTCLIENT_BATTLEPASS_NEWBONUSRANK,You reached the %s bonus grade %d+%d!,%sボーナス等級%d+%dに到達しました！
 TEXTCLIENT_BATTLEPASS_ENDED,There is no more active Flyff Pass.,アクティブなバトルパスはもうありません。
 TEXTCLIENT_BATTLEPASS_PAID,Thank you for purchasing the Extended %s!,拡張%sをお買い上げいただきありがとうございます!
 TEXTCLIENT_BATTLEPASS_PURCHASE_PAID,Purchase the Extended %s to receive more rewards!,拡張 %s を購入すると、より多くの報酬を獲得できます!
 TEXTCLIENT_GUILDCOMBAT80_MAXLEVEL,Only characters level 80 or less can apply to this Lv80 Guild Siege.,このLv80ギルドコンバットは、レベル80以下のキャラクターのみ適用可能です。
 TEXTCLIENT_GUILDCOMBAT60_MAXLEVEL,Only characters who did not complete the second class change can apply to this Lv60 Guild Siege.,今回のLv60ギルドコンバットは、2次転職を完了していないキャラクターのみ応募可能です。
-TEXTCLIENT_GUILDCOMBAT165_MAXLEVEL,Only characters who did not complete the third class change can apply to this Lv165 Guild Siege.,Only characters who did not complete the third class change can apply to this Lv165 Guild Siege.
+TEXTCLIENT_GUILDCOMBAT165_MAXLEVEL,Only characters who did not complete the third class change can apply to this Lv165 Guild Siege.,3次職への転職を完了していないキャラクターのみ、このLv165ギルドコンバットに申請できます。
 TEXTCLIENT_GUILDCOMBAT_ENTER1,The Lv80 Guild Siege is held for this week.,今週はLv80ギルドコンバットが開催されます。
 TEXTCLIENT_GUILDCOMBAT_ENTER2,The Lv60 Guild Siege is held for this week.,今週はLv60ギルドコンバットが開催されます。
-TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT1,Today's Lv80 Guild Siege will not be held due to lack of participants.,Today's Lv80 Guild Siege will not be held due to lack of participants.
-TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT2,Today's Lv60 Guild Siege will not be held due to lack of participants.,Today's Lv60 Guild Siege will not be held due to lack of participants.
+TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT1,Today's Lv80 Guild Siege will not be held due to lack of participants.,本日のLv80ギルドコンバットは、参加者不足のため開催されません。
+TEXTCLIENT_GUILDCOMBAT_NEXT_COMBAT2,Today's Lv60 Guild Siege will not be held due to lack of participants.,本日のLv60ギルドコンバットは、参加者不足のため開催されません。
 TEXTCLIENT_GUILDCOMBAT_END1,The Level 80 Guild Siege has ended.,Lv80ギルドコンバットが終了しました。
 TEXTCLIENT_GUILDCOMBAT_END2,The Level 60 Guild Siege has ended.,Lv80ギルドコンバットが終了しました。
 TEXTCLIENT_GUILDCOMBAT_CHIPS,%d %s have been sent to your inventory or mail box.,%d %s がインベントリまたはメール ボックスに送信されました。
@@ -956,7 +956,7 @@ TEXTCLIENT_DUNGEON_RATELIMIT,Too many players are starting dungeons. Please try 
 TEXTCLIENT_DUNGEON_FAILMASTER,You cannot enter dungeons while on a Master quest.,マスタークエスト中はダンジョンに入ることができません。
 TEXTCLIENT_ITEM_PK,This item is only usable on a PK Channel.,このアイテムは、PKチャンネルでのみ使用可能です。
 TEXTCLIENT_DUNGEON_RANKING_MAIL,Congratulations for your rank %d in the %s!,ランク%d到達おめでとうございます！%s！
-TEXTCLIENT_DUNGEON_WINNER,This week's winner of the %s is %s Guild,今週の勝者は %s ！そして、ギルド %s！
+TEXTCLIENT_DUNGEON_WINNER,This week's winner of the %s is %s Guild,今週の%sの勝者はギルド%sです！
 TEXTCLIENT_DUNGEON_NOWINNER,There is no winning Guild of the %s,今回は勝者がいませんでしたが、ギルドは %sです。
 TEXTCLIENT_CHANNELPK,You cannot teleport on a non-PK channel while using a PK ticket,PKチケット使用中は、PK以外のチャンネルへテレポートできません。
 TEXTCLIENT_DUNGEON_CLEARED,Dungeon cleared in %s!,%s ダンジョンクリア！
@@ -979,7 +979,7 @@ TEXTCLIENT_MESSAGE_TOO_LONG,Your message exceeds the maximum length.,メッセ�
 TEXTCLIENT_FREEZE_NOTUSE,You cannot teleport if you're frozen.,凍り付いているとテレポートできません。
 TEXTCLIENT_MINLVLTRADE,You must reach level %d to trade premium items.,プレミアムアイテムを交換するには、レベル%dに到達する必要があります。
 TEXTCLIENT_MINLVLMOTION,You must reach level %d to use this emote.,このモーションを使用するには、レベル %d に到達する必要があります。
-TEXTCLIENT_APP_SWITCHEQUIP,Switch Equip,Switch Equip
+TEXTCLIENT_APP_SWITCHEQUIP,Switch Equip,装備切替
 TEXTCLIENT_SWITCHEQUIP_NOTUSEITEM,You can only equip items from the SwitchEquip menu/shortcut.,アイテムはスイッチ装備のメニュー/ショートカットからのみ装備できます。
 TEXTCLIENT_SWITCHEQUIP_SUCCESS_UPDATED,You Successfully updated preset %s!,プリセット %s の更新に成功しました!
 TEXTCLIENT_SWITCHEQUIP_ERROR_COUNT,You have too many presets!,プリセットが多すぎます!
@@ -1020,7 +1020,7 @@ TEXTCLIENT_PVPCONTEST_NO_OUTWAR,You cannot use Blinkwings to escape the FWC PVP 
 TEXTCLIENT_PVPCONTEST_MATCHEND_WINNER,Match has ended! Winner is %s!,試合終了!勝者は %s です!
 TEXTCLIENT_PVPCONTEST_MATCHEND_NOWINNER,Match has ended! There was no winner this time!,試合終了!今回は勝者がいませんでした!
 TEXTCLIENT_PVPCONTEST_CAPTION_WAITINGOPPONENT,Waiting for opponent.. ,対戦相手を待っています.. 
-TEXTCLIENT_PVPCONTEST_CAPTION_PREPARE,Preparation phase. Match will start in: ,Preparation phase. Match will start in: 
+TEXTCLIENT_PVPCONTEST_CAPTION_PREPARE,Preparation phase. Match will start in: ,準備フェーズ。試合開始まで：
 TEXTCLIENT_PVPCONTEST_CAPTION_FIGHT,End combat  ,戦闘終了
 TEXTCLIENT_PVPCONTEST_CAPTION_ENDING,Match has ended! You will be teleported on Madrigal in ,試合終了!マドリガルにテレポートします。
 TEXTCLIENT_PVPCONTEST_SCHEDULES_LEADER,Only the leader can select match schedules!,試合日程はリーダーしか選べません!
@@ -1030,8 +1030,8 @@ TEXTCLIENT_PVPCONTEST_TELEPORTNOMATCH,Teleportation is not possible since there 
 TEXTCLIENT_PVPCONTEST_NOOPPONENT,"No opponent joined! Match will then end, giving you the victory!",対戦相手は参加しませんでした!その後、試合が終了し、勝利が与えられます!
 TEXTCLIENT_PVPCONTEST_NOOPPONENTWIN,No opponent was found for your match! We then considered your match as won!,対戦相手が見つかりませんでした!その後、あなたの試合は勝利と見なされました!
 TEXTCLIENT_PVPCONTEST_KILLNOTIFICATION,[%s] %s killed [%s] %s!,[%s] %s が [%s] %s を倒しました!
-TEXTCLIENT_PVPCONTEST_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped their killing spree!,[%s] %s killed [%s] %s and stopped their killing spree!
-TEXTCLIENT_PVPCONTEST_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is on a killing spree!,[%s] %s is on a killing spree!
+TEXTCLIENT_PVPCONTEST_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped their killing spree!,[%s]%sが[%s]%sを倒し、連続撃破を止めた！
+TEXTCLIENT_PVPCONTEST_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is on a killing spree!,[%s]%sが連続撃破中！
 TEXTCLIENT_PVPCONTEST_MATCHSOON,You can't change your participation now. Matches are starting soon!,今すぐ参加を変更することはできません。まもなく試合が始まります!
 TEXTCLIENT_PVPCONTEST_PLAYERNOTJOINED_LIVES,A player has not joined or has left the match! Total guild remaining lives have been decreased by %d!,プレイヤーがマッチに参加していないか、マッチから退出しています!ギルドの残りライフが%d減少しました!
 TEXTCLIENT_PVPCONTEST_PRELIMINARYMATCHESENDANNOUNCEMENT,The FWC PVP Contest Preliminary %d:%d UTC matches have ended! The next matches will start at %d:%d UTC!,FWC PvP コンテスト予選 %d:%d UTC の試合は終了しました!次のマッチは %d:%d UTC に開始されます!
@@ -1071,8 +1071,8 @@ TEXTCLIENT_BANKEXTRABAG_INUSE,You are already using Bank Extra Bag.,すでにバ
 TEXTCLIENT_BANKEXTRABAG_USED,Bank is now expanded.,銀行は現在拡張されています。
 TEXTCLIENT_CANNOT_USE_COMBAT,You cannot use the item during combat.,戦闘中は使用できません。
 TEXTCLIENT_RAINBOWRACE_ITEMUSED,%s Used %s on you!,%s 使用済み %s です!
-TEXTCLIENT_RAINBOWRACE_USEITEM,You used %s on %s!,You used %s on %s!
-TEXTCLIENT_RAINBOWRACE_USEITEM_SELF,You used %s!,You used %s!
+TEXTCLIENT_RAINBOWRACE_USEITEM,You used %s on %s!,%sを%sに使用しました！
+TEXTCLIENT_RAINBOWRACE_USEITEM_SELF,You used %s!,%sを使用しました！
 TEXTCLIENT_RAINBOWRACE_USEITEM_NOTARGET,No target found.,ターゲットが見つかりませんでした。
 TEXTCLIENT_RAINBOWRACE_USEITEM_TARGETBARRIER,The target blocked with a Rainbow Barrier!,ターゲットをレインボーバリアでブロック!
 TEXTCLIENT_RAINBOWRACE_USEITEM_USERBARRIER,You've blocked an item with your Rainbow Barrier!,レインボーバリアでアイテムをブロックしました!
@@ -1173,12 +1173,12 @@ TEXTCLIENT_HOUSINGPRESETS_SUCCESS01,You can now have a maximum of %d housing pre
 TEXTCLIENT_HOUSING_NOSHOP,You can't open a private shop in houses!,ハウスで個人商店を開くことはできません!
 TEXTCLIENT_HOUSING_NORETURNSCROLL,You cannot use a return scroll in houses!,家の中では返却巻物は使えません!
 TEXTCLIENT_RANDOMSCROLL_BEST,This item already has the best random stat possible.,このアイテムは、すでに可能な限り最高のランダムステータスを持っています。
-TEXTCLIENT_DUNGEON_CUSTOM_OBJECTIVE,%d minute(s) remaining to %s,%d minute(s) remaining to %s
+TEXTCLIENT_DUNGEON_CUSTOM_OBJECTIVE,%d minute(s) remaining to %s,残り%d分、%sまで
 TEXTCLIENT_RAINBOWRACE_BLINK,You cannot teleport during the rainbow race.,レインボーレース中にテレポートすることはできません。
 TEXTCLIENT_RAINBOWRACE_DISQUALIFY,You have been disqualified from the race.,あなたはレースから失格となりました。
 TEXTCLIENT_RAINBOWRACE_PREANNOUNCE,The Rainbow Race will begin in 10 minutes! Register in Darken City.,まもなく10分後にレインボーレース開始！参加登録はダーコンへ！
 TEXTCLIENT_BANK_EXTRABAG_USED,Bank is now expanded.,銀行は現在拡張されています。
-TEXTCLIENT_RAINBOWRACE_NOBOARD,You cannot enter the Rainbow Race because equipping the flying item failed.,You cannot enter the Rainbow Race because equipping the flying item failed.
+TEXTCLIENT_RAINBOWRACE_NOBOARD,You cannot enter the Rainbow Race because equipping the flying item failed.,飛行アイテムの装備に失敗したため、レインボーレースに参加できません。
 TEXTCLIENT_EXTERNALLOGIN,Direct sign in is not available. Please sign in from the website.,直接サインインはできません。ウェブサイトからサインインしてください。
 TEXTCLIENT_EVENTBUFF,%s is active!,%s はアクティブです!
 TEXTCLIENT_STORAGEFULL,The bag is full.,バッグがいっぱいです。
@@ -1230,18 +1230,18 @@ TEXTCLIENT_KALGAS_ENTER_NOTRANS,You cannot enter an Kalgas Assault while you are
 TEXTCLIENT_PARTYSKILL_NOTUSE,You cannot use party skills in this area.,このエリアではパーティースキルは使用できません。
 TEXTCLIENT_HOUSINGGUESTBOOK_COOLDOWN,Please wait a little before posting another guest book message.,少し待ってから、別のゲストブックメッセージを投稿してください。
 TEXTCLIENT_HOUSINGTEMPLATE_PLAYERSIN,There are still some players in your house. You can't change the template until there's nobody left inside.,あなたの家にはまだ何人かのプレイヤーがいます。内部に誰もいなくなるまで、テンプレートを変更することはできません。
-TEXTCLIENT_RAINBOWRACE_NOPENYA_TEAM,%s does not have enough Penya to apply for the Rainbow Race.,%s does not have enough Penya to apply for the Rainbow Race.
-TEXTCLIENT_RAINBOWRACE_OTHER_ACTIONS,%s is during other actions.,%s is during other actions.
-TEXTCLIENT_RAINBOWRACE_TEAM_DISTRIBUTION,Teams will be randomly matched after %d seconds,Teams will be randomly matched after %d seconds
-TEXTCLIENT_RAINBOWRACE_TELEPORT_CLOSED,Teleportation is no longer available.,Teleportation is no longer available.
-TEXTCLIENT_RAINBOWRACE_INVITATION_INPROGRESS,Team member invitations are in progress.,Team member invitations are in progress.
-TEXTCLIENT_RAINBOWRACE_REGISTERED_USER,%s has already registered for the race.,%s has already registered for the race.
-TEXTCLIENT_RAINBOWRACE_INVITED_USER,%s has already received an invitation.,%s has already received an invitation.
-TEXTCLIENT_RAINBOWRACE_REGISTER_FAILED,Failed to register for the Rainbow Race.,Failed to register for the Rainbow Race.
-TEXTCLIENT_RAINBOWRACE_CANNOT_APPLY,It's currently not possible to apply.,It's currently not possible to apply.
-TEXTCLIENT_RAINBOWRACE_INVITATION_OFFLINE,You can only invite users who are online.,You can only invite users who are online.
-TEXTCLIENT_RAINBOWRACE_INVITATION_CANCELED,The Rainbow Race team invitation has been canceled.,The Rainbow Race team invitation has been canceled.
-TEXTCLIENT_RAINBOWRACE_INVITATION_REFUSED,%s has refused to invite.,%s has refused to invite.
+TEXTCLIENT_RAINBOWRACE_NOPENYA_TEAM,%s does not have enough Penya to apply for the Rainbow Race.,%sはレインボーレースに申請するためのペニャが不足しています。
+TEXTCLIENT_RAINBOWRACE_OTHER_ACTIONS,%s is during other actions.,%sは他の行動中です。
+TEXTCLIENT_RAINBOWRACE_TEAM_DISTRIBUTION,Teams will be randomly matched after %d seconds,%d秒後にチームがランダムに編成されます
+TEXTCLIENT_RAINBOWRACE_TELEPORT_CLOSED,Teleportation is no longer available.,テレポートは利用できません。
+TEXTCLIENT_RAINBOWRACE_INVITATION_INPROGRESS,Team member invitations are in progress.,チームメンバーの招待中です。
+TEXTCLIENT_RAINBOWRACE_REGISTERED_USER,%s has already registered for the race.,%sは既にレースに登録済みです。
+TEXTCLIENT_RAINBOWRACE_INVITED_USER,%s has already received an invitation.,%sは既に招待を受け取っています。
+TEXTCLIENT_RAINBOWRACE_REGISTER_FAILED,Failed to register for the Rainbow Race.,レインボーレースへの登録に失敗しました。
+TEXTCLIENT_RAINBOWRACE_CANNOT_APPLY,It's currently not possible to apply.,現在申請できません。
+TEXTCLIENT_RAINBOWRACE_INVITATION_OFFLINE,You can only invite users who are online.,オンラインのユーザーのみ招待できます。
+TEXTCLIENT_RAINBOWRACE_INVITATION_CANCELED,The Rainbow Race team invitation has been canceled.,レインボーレースのチーム招待がキャンセルされました。
+TEXTCLIENT_RAINBOWRACE_INVITATION_REFUSED,%s has refused to invite.,%sが招待を拒否しました。
 TEXTCLIENT_KALGASASSAULT_FAIL_MASTER,You cannot play Kalgas Assault during the master quest.,マスタークエスト中はカルガスアサルトをプレイできません。
 TEXTCLIENT_ITEMOTHERPLAYER,The %s belongs to another player.,%sは別のプレイヤーのものです。
 TEXTCLIENT_CHAT_NO_TEAM,You are not a member of a team.,あなたはチームメンバーではありません。
@@ -1256,321 +1256,321 @@ TEXTCLIENT_MAGIC_CLOCK_LIMIT,You've already used maximum count of Magic Clock,�
 TEXTCLIENT_MAGIC_CLOCK_SHORT_TIME,Remaining cooldown for the instance dungeon is shorter than the item's effect. Are you sure you want to use the item?,インスタンスダンジョンの残りクールダウンはアイテムの効果よりも短いです。アイテムを使用してもよろしいですか?
 TEXTCLIENT_CONTINENT_MINLEVEL,You must reach level %d to access this area.,このエリアにアクセスするには、レベル %d に到達する必要があります。
 TEXTCLIENT_SUMMON_MINLEVEL,You cannot summon a player below level %d.,レベル %d 以下のプレイヤーは召喚できません。
-TEXTCLIENT_SUMMON_MINLEVELPARTY,You cannot summon %s because the level is below %d.,You cannot summon %s because the level is below %d.
+TEXTCLIENT_SUMMON_MINLEVELPARTY,You cannot summon %s because the level is below %d.,%sはレベルが%d未満のため召喚できません。
 TEXTCLIENT_COLLECT_GUEST,Guest Characters cannot equip this item. Please link an account.,ゲストキャラクターは装備できません。アカウント連携をお願いします。
-TEXTCLIENT_ACCOUNT_DELETED,Your account has been successfully deleted.,Your account has been successfully deleted.
-TEXTCLIENT_ACCOUNT_DELETIONFAILED,Your password is invalid.,Your password is invalid.
-TEXTCLIENT_NOT_ENOUGH_ITEM,Not enough %s.,Not enough %s.
-TEXTCLIENT_CRAFTANNOUNCE,%s crafted %s!,%s crafted %s!
-TEXTCLIENT_TRADE_DISTANCE,You cannot trade due to distance.,You cannot trade due to distance.
-TEXTCLIENT_COUPON_ITEM_SUCCESS,The coupon has been submitted successfully. Please check your Post Box.,The coupon has been submitted successfully. Please check your Post Box.
-TEXTCLIENT_COUPON_CASH_SUCCESS,The coupon has been submitted successfully. Please check in the Flyff Shop.,The coupon has been submitted successfully. Please check in the Flyff Shop.
-TEXTCLIENT_COUPON_ALREADYUSED,Coupon has already been used.,Coupon has already been used.
-TEXTCLIENT_COUPON_LIMITREACHED,The coupon usage limit has been reached.,The coupon usage limit has been reached.
-TEXTCLIENT_COUPON_NOTFOUND,No coupon found with this code. Please try again.,No coupon found with this code. Please try again.
-TEXTCLIENT_COUPON_INVALIDCODE,Invalid coupon code. Please try again.,Invalid coupon code. Please try again.
-TEXTCLIENT_COUPON_LEVELTOOLOW,You need a higher level to redeem this coupon.,You need a higher level to redeem this coupon.
-TEXTCLIENT_COUPONGIFT_MAIL_TITLE,Coupon Gift,Coupon Gift
-TEXTCLIENT_COMBAT_NOTTRADE,You cannot trade during combat.,You cannot trade during combat.
-TEXTCLIENT_EVENT_PREFIX,[Event],[Event]
-TEXTCLIENT_ACCOUNTDISCONNECTED,Account %d disconnected.,Account %d disconnected.
-TEXTCLIENT_ACCOUNTNOTEXIST,Account %d does not exist or is offline.,Account %d does not exist or is offline.
-TEXTCLIENT_ACCOUNTDISCONNECTSELF,You cannot disconnect yourself.,You cannot disconnect yourself.
-TEXTCLIENT_APP_SEARCHSHOP,Search Shop,Search Shop
-TEXTCLIENT_PARTY_READY_ON,There is already a ready check in progress.,There is already a ready check in progress.
-TEXTCLIENT_PIRATESHIP_APPEARS,There is a Pirate Ship above the Madrigal!!,There is a Pirate Ship above the Madrigal!!
-TEXTCLIENT_PARTY_READY_LEADER,"Only the leader may start a ready check, and there is not one currently in progress.","Only the leader may start a ready check, and there is not one currently in progress."
-TEXTCLIENT_THROWITEM_ERROR_15,It can only be used when the target is within 15 meters.,It can only be used when the target is within 15 meters.
-TEXTCLIENT_THROWITEM_ERROR_TARGET,There is no target to use it on.,There is no target to use it on.
-TEXTCLIENT_THROWITEM_ERROR_AREA,You cannot use it there.,You cannot use it there.
-TEXTCLIENT_SEARCHSHOP_TPSELF,You cannot teleport to yourself.,You cannot teleport to yourself.
-TEXTCLIENT_SEARCHSHOP_CLOSED,The shop has been closed.,The shop has been closed.
-TEXTCLIENT_PVPMATCH_TEAM,Team ,Team 
+TEXTCLIENT_ACCOUNT_DELETED,Your account has been successfully deleted.,アカウントの削除が完了しました。
+TEXTCLIENT_ACCOUNT_DELETIONFAILED,Your password is invalid.,パスワードが正しくありません。
+TEXTCLIENT_NOT_ENOUGH_ITEM,Not enough %s.,%sが不足しています。
+TEXTCLIENT_CRAFTANNOUNCE,%s crafted %s!,%sが%sを製作しました！
+TEXTCLIENT_TRADE_DISTANCE,You cannot trade due to distance.,距離が離れているため取引できません。
+TEXTCLIENT_COUPON_ITEM_SUCCESS,The coupon has been submitted successfully. Please check your Post Box.,クーポンの送信が完了しました。郵便箱をご確認ください。
+TEXTCLIENT_COUPON_CASH_SUCCESS,The coupon has been submitted successfully. Please check in the Flyff Shop.,クーポンの送信が完了しました。Flyffショップをご確認ください。
+TEXTCLIENT_COUPON_ALREADYUSED,Coupon has already been used.,このクーポンは既に使用されています。
+TEXTCLIENT_COUPON_LIMITREACHED,The coupon usage limit has been reached.,クーポンの利用上限に達しました。
+TEXTCLIENT_COUPON_NOTFOUND,No coupon found with this code. Please try again.,このコードのクーポンが見つかりません。もう一度お試しください。
+TEXTCLIENT_COUPON_INVALIDCODE,Invalid coupon code. Please try again.,クーポンコードが無効です。もう一度お試しください。
+TEXTCLIENT_COUPON_LEVELTOOLOW,You need a higher level to redeem this coupon.,このクーポンを利用するには、より高いレベルが必要です。
+TEXTCLIENT_COUPONGIFT_MAIL_TITLE,Coupon Gift,クーポンギフト
+TEXTCLIENT_COMBAT_NOTTRADE,You cannot trade during combat.,戦闘中は取引できません。
+TEXTCLIENT_EVENT_PREFIX,[Event],[イベント]
+TEXTCLIENT_ACCOUNTDISCONNECTED,Account %d disconnected.,アカウント%dが切断されました。
+TEXTCLIENT_ACCOUNTNOTEXIST,Account %d does not exist or is offline.,アカウント%dは存在しないか、オフラインです。
+TEXTCLIENT_ACCOUNTDISCONNECTSELF,You cannot disconnect yourself.,自分自身を切断することはできません。
+TEXTCLIENT_APP_SEARCHSHOP,Search Shop,ショップ検索
+TEXTCLIENT_PARTY_READY_ON,There is already a ready check in progress.,準備確認は既に進行中です。
+TEXTCLIENT_PIRATESHIP_APPEARS,There is a Pirate Ship above the Madrigal!!,マドリガルの上空に海賊船が出現しました！！
+TEXTCLIENT_PARTY_READY_LEADER,"Only the leader may start a ready check, and there is not one currently in progress.",準備確認を開始できるのはパーティーリーダーのみで、現在進行中の準備確認はありません。
+TEXTCLIENT_THROWITEM_ERROR_15,It can only be used when the target is within 15 meters.,対象が15メートル以内にいる場合のみ使用できます。
+TEXTCLIENT_THROWITEM_ERROR_TARGET,There is no target to use it on.,使用対象がありません。
+TEXTCLIENT_THROWITEM_ERROR_AREA,You cannot use it there.,そこでは使用できません。
+TEXTCLIENT_SEARCHSHOP_TPSELF,You cannot teleport to yourself.,自分自身にはテレポートできません。
+TEXTCLIENT_SEARCHSHOP_CLOSED,The shop has been closed.,ショップは閉店しました。
+TEXTCLIENT_PVPMATCH_TEAM,Team ,チーム
 TEXTCLIENT_PVPMATCH_MATCHEND_WINNER,Match has ended! Winner is %s!,試合終了!勝者は %s です!
 TEXTCLIENT_PVPMATCH_MATCHEND_NOWINNER,Match has ended! There was no winner this time!,試合終了!今回は勝者がいませんでした!
-TEXTCLIENT_PVPMATCH_CANTTELEPORT,You can't teleport in the match anymore. Match has ended.,You can't teleport in the match anymore. Match has ended.
+TEXTCLIENT_PVPMATCH_CANTTELEPORT,You can't teleport in the match anymore. Match has ended.,試合が終了したため、これ以上テレポートできません。
 TEXTCLIENT_PVPMATCH_NOOPPONENT,"No opponent joined! Match will then end, giving you the victory!",対戦相手は参加しませんでした!その後、試合が終了し、勝利が与えられます!
 TEXTCLIENT_PVPMATCH_NOOPPONENTWIN,No opponent was found for your match! We then considered your match as won!,対戦相手が見つかりませんでした!その後、あなたの試合は勝利と見なされました!
 TEXTCLIENT_PVPMATCH_KILLNOTIFICATION,[%s] %s killed [%s] %s!,[%s] %s が [%s] %s を倒しました!
-TEXTCLIENT_PVPMATCH_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped his killing spree!,[%s] %s killed [%s] %s and stopped his killing spree!
-TEXTCLIENT_PVPMATCH_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is in a killing spree!,[%s] %s is in a killing spree!
+TEXTCLIENT_PVPMATCH_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped his killing spree!,[%s]%sが[%s]%sを倒し、連続撃破を止めた！
+TEXTCLIENT_PVPMATCH_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is in a killing spree!,[%s]%sが連続撃破中！
 TEXTCLIENT_PVPMATCH_PLAYERNOTJOINED_LIVES,A player has not joined or has left the match! Total guild remaining lives have been decreased by %d!,プレイヤーがマッチに参加していないか、マッチから退出しています!ギルドの残りライフが%d減少しました!
 TEXTCLIENT_PVPMATCH_SPECT_ERROR_2,The match you're trying to spectate is ending. Please select another one.,あなたが観戦しようとしている試合が終わろうとしています。別のものを選択してください。
-TEXTCLIENT_PVPMATCH_CANNOT_FRIENDADD,You cannot add friends in a PVP Match.,You cannot add friends in a PVP Match.
-TEXTCLIENT_PVPMATCH_CANNOT_PARTY,You cannot make a party in a PVP Match.,You cannot make a party in a PVP Match.
-TEXTCLIENT_PVPMATCH_NO_OUTWAR,You cannot use Blinkwings to escape a PVP Match.,You cannot use Blinkwings to escape a PVP Match.
-TEXTCLIENT_PVPMATCH_MANUAL_ALREADYIN,This player is already in a team.,This player is already in a team.
-TEXTCLIENT_PVPMATCH_MANUAL_NOTGM,You can only add gamemasters to the observers team.,You can only add gamemasters to the observers team.
-TEXTCLIENT_PVPMATCH_MANUAL_NOTONLINE,This character is needs to be online.,This character is needs to be online.
-TEXTCLIENT_PVPMATCH_MANUAL_NOTYOURSELF,You can't invite yourself in a match.,You can't invite yourself in a match.
-TEXTCLIENT_PVPMATCH_MANUAL_NOTALLREADY,"All players are not ready, you can't start the match yet.","All players are not ready, you can't start the match yet."
-TEXTCLIENT_PVPMATCH_MANUAL_MAXPLAYERS,You can't add more than %d players in the same team!,You can't add more than %d players in the same team!
-TEXTCLIENT_GAME_MATOURNAMENT_NOTUSE,In Madrigal Tournament,In Madrigal Tournament
-TEXTCLIENT_MATOURNAMENT_NO_OUTWAR,You cannot use Blinkwings to escape the Madrigal Tournament.,You cannot use Blinkwings to escape the Madrigal Tournament.
-TEXTCLIENT_MATOURNAMENT_NOTUSEITEM,You cannot use items in the Madrigal Tournament.,You cannot use items in the Madrigal Tournament.
-TEXTCLIENT_TRANS_LOTTERY_MATOURNAMENT,You can't use the roulette in the Madrigal Tournament.,You can't use the roulette in the Madrigal Tournament.
-TEXTCLIENT_MATOURNAMENT_CANNOT_TRADE,You cannot trade in the Madrigal Tournament.,You cannot trade in the Madrigal Tournament.
-TEXTCLIENT_MATOURNAMENT_CANNOT_PARTY,You cannot make a party in the Madrigal Tournament.,You cannot make a party in the Madrigal Tournament.
-TEXTCLIENT_MATOURNAMENT_CANNOT_FRIENDADD,You cannot add friends in the Madrigal Tournament.,You cannot add friends in the Madrigal Tournament.
-TEXTCLIENT_MATOURNAMENT_HAVENOT_MASTER,party leader has to participate to the Madrigal Tournament!,party leader has to participate to the Madrigal Tournament!
+TEXTCLIENT_PVPMATCH_CANNOT_FRIENDADD,You cannot add friends in a PVP Match.,PVPマッチ中はフレンド追加できません。
+TEXTCLIENT_PVPMATCH_CANNOT_PARTY,You cannot make a party in a PVP Match.,PVPマッチ中はパーティーを組めません。
+TEXTCLIENT_PVPMATCH_NO_OUTWAR,You cannot use Blinkwings to escape a PVP Match.,PVPマッチ中はブリンクウィングで離脱できません。
+TEXTCLIENT_PVPMATCH_MANUAL_ALREADYIN,This player is already in a team.,このプレイヤーは既にチームに所属しています。
+TEXTCLIENT_PVPMATCH_MANUAL_NOTGM,You can only add gamemasters to the observers team.,観戦者チームにはゲームマスターのみ追加できます。
+TEXTCLIENT_PVPMATCH_MANUAL_NOTONLINE,This character is needs to be online.,このキャラクターはオンラインである必要があります。
+TEXTCLIENT_PVPMATCH_MANUAL_NOTYOURSELF,You can't invite yourself in a match.,自分自身を試合に招待することはできません。
+TEXTCLIENT_PVPMATCH_MANUAL_NOTALLREADY,"All players are not ready, you can't start the match yet.",全プレイヤーの準備が完了していないため、まだ試合を開始できません。
+TEXTCLIENT_PVPMATCH_MANUAL_MAXPLAYERS,You can't add more than %d players in the same team!,同じチームには%d人を超えて追加できません！
+TEXTCLIENT_GAME_MATOURNAMENT_NOTUSE,In Madrigal Tournament,マドリガルトーナメント中
+TEXTCLIENT_MATOURNAMENT_NO_OUTWAR,You cannot use Blinkwings to escape the Madrigal Tournament.,マドリガルトーナメント中はブリンクウィングで離脱できません。
+TEXTCLIENT_MATOURNAMENT_NOTUSEITEM,You cannot use items in the Madrigal Tournament.,マドリガルトーナメント中はアイテムを使用できません。
+TEXTCLIENT_TRANS_LOTTERY_MATOURNAMENT,You can't use the roulette in the Madrigal Tournament.,マドリガルトーナメント中はルーレットを使用できません。
+TEXTCLIENT_MATOURNAMENT_CANNOT_TRADE,You cannot trade in the Madrigal Tournament.,マドリガルトーナメント中は取引できません。
+TEXTCLIENT_MATOURNAMENT_CANNOT_PARTY,You cannot make a party in the Madrigal Tournament.,マドリガルトーナメント中はパーティーを組めません。
+TEXTCLIENT_MATOURNAMENT_CANNOT_FRIENDADD,You cannot add friends in the Madrigal Tournament.,マドリガルトーナメント中はフレンド追加できません。
+TEXTCLIENT_MATOURNAMENT_HAVENOT_MASTER,party leader has to participate to the Madrigal Tournament!,マドリガルトーナメントにはパーティーリーダーが参加している必要があります！
 TEXTCLIENT_MATOURNAMENT_CAPTION_WAITINGOPPONENT,Waiting for opponent.. ,対戦相手を待っています.. 
-TEXTCLIENT_MATOURNAMENT_CAPTION_PREPARE,Preparation phase. Match will start in ,Preparation phase. Match will start in 
+TEXTCLIENT_MATOURNAMENT_CAPTION_PREPARE,Preparation phase. Match will start in ,準備フェーズ。試合開始まで：
 TEXTCLIENT_MATOURNAMENT_CAPTION_FIGHT,End combat  ,戦闘終了
-TEXTCLIENT_MATOURNAMENT_CAPTION_ENDING,Match has ended! You will be teleported on Madrigal in,Match has ended! You will be teleported on Madrigal in
-TEXTCLIENT_MATOURNAMENT_NOT_REGISTRABLE_TIME,Registration is not available at this time.,Registration is not available at this time.
-TEXTCLIENT_MATOURNAMENT_NOPARTY,You are not in a party.,You are not in a party.
-TEXTCLIENT_MATOURNAMENT_NOTPARTYLEADER,You are not the party leader.,You are not the party leader.
-TEXTCLIENT_MATOURNAMENT_INVALID_MEMBER_COUNT,Invalid number of party members.,Invalid number of party members.
-TEXTCLIENT_MATOURNAMENT_ALREADY_REGISTERED,A party member is already registered.,A party member is already registered.
-TEXTCLIENT_MATOURNAMENT_MEMBER_OFFLINE,Not all party members are online.,Not all party members are online.
-TEXTCLIENT_MATOURNAMENT_MEMBER_MINLEVEL,A party member does not meet the minimum level requirement.,A party member does not meet the minimum level requirement.
-TEXTCLIENT_MATOURNAMENT_NOGOLDS,Not enough Penya.,Not enough Penya.
-TEXTCLIENT_MATOURNAMENT_REGISTRATIONSUCCESS,Registration successful.,Registration successful.
-TEXTCLIENT_MATOURNAMENT_WINNER,The Madrigal Tournament has ended! The winner is: %s! Congratulations!,The Madrigal Tournament has ended! The winner is: %s! Congratulations!
-TEXTCLIENT_MATOURNAMENT_NO_WINNER,The Madrigal Tournament has ended on a draw! Congratulations!,The Madrigal Tournament has ended on a draw! Congratulations!
-TEXTCLIENT_MATOURNAMENT_TELEPORTNOMATCH,You can't enter because there is no match available.,You can't enter because there is no match available.
+TEXTCLIENT_MATOURNAMENT_CAPTION_ENDING,Match has ended! You will be teleported on Madrigal in,試合が終了しました！マドリガルへのテレポートまで：
+TEXTCLIENT_MATOURNAMENT_NOT_REGISTRABLE_TIME,Registration is not available at this time.,現在、登録は利用できません。
+TEXTCLIENT_MATOURNAMENT_NOPARTY,You are not in a party.,パーティーに参加していません。
+TEXTCLIENT_MATOURNAMENT_NOTPARTYLEADER,You are not the party leader.,パーティーリーダーではありません。
+TEXTCLIENT_MATOURNAMENT_INVALID_MEMBER_COUNT,Invalid number of party members.,パーティーメンバー人数が不正です。
+TEXTCLIENT_MATOURNAMENT_ALREADY_REGISTERED,A party member is already registered.,パーティーメンバーが既に登録されています。
+TEXTCLIENT_MATOURNAMENT_MEMBER_OFFLINE,Not all party members are online.,パーティーメンバー全員がオンラインではありません。
+TEXTCLIENT_MATOURNAMENT_MEMBER_MINLEVEL,A party member does not meet the minimum level requirement.,パーティーメンバーの中に最低レベル条件を満たしていない者がいます。
+TEXTCLIENT_MATOURNAMENT_NOGOLDS,Not enough Penya.,ペニャが不足しています。
+TEXTCLIENT_MATOURNAMENT_REGISTRATIONSUCCESS,Registration successful.,登録が完了しました。
+TEXTCLIENT_MATOURNAMENT_WINNER,The Madrigal Tournament has ended! The winner is: %s! Congratulations!,マドリガルトーナメントが終了しました！優勝者は%s！おめでとうございます！
+TEXTCLIENT_MATOURNAMENT_NO_WINNER,The Madrigal Tournament has ended on a draw! Congratulations!,マドリガルトーナメントは引き分けで終了しました！お疲れ様でした！
+TEXTCLIENT_MATOURNAMENT_TELEPORTNOMATCH,You can't enter because there is no match available.,参加可能な試合がないため、入場できません。
 TEXTCLIENT_MATOURNAMENT_NOOPPONENT,"No opponent joined! Match will then end, giving you the victory!",対戦相手は参加しませんでした!その後、試合が終了し、勝利が与えられます!
-TEXTCLIENT_MATOURNAMENT_PLAYERNOTJOINED_LIVES,A player has not joined or has left the match! Total Team remaining lives have been decreased by %d!,A player has not joined or has left the match! Total Team remaining lives have been decreased by %d!
+TEXTCLIENT_MATOURNAMENT_PLAYERNOTJOINED_LIVES,A player has not joined or has left the match! Total Team remaining lives have been decreased by %d!,参加していない、または離脱したプレイヤーがいます！チームの残機が%d減少しました！
 TEXTCLIENT_MATOURNAMENT_NOOPPONENT_WIN,No opponent was found for your match! We then considered your match as won!,対戦相手が見つかりませんでした!その後、あなたの試合は勝利と見なされました!
 TEXTCLIENT_MATOURNAMENT_MATCHEND_NOWINNER,Match has ended! There was no winner this time!,試合終了!今回は勝者がいませんでした!
 TEXTCLIENT_MATOURNAMENT_MATCHEND_WINNER,Match has ended! Winner is %s!,試合終了!勝者は %s です!
 TEXTCLIENT_MATOURNAMENT_KILLNOTIFICATION,[%s] %s killed [%s] %s!,[%s] %s が [%s] %s を倒しました!
-TEXTCLIENT_MATOURNAMENT_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped his killing spree!,[%s] %s killed [%s] %s and stopped his killing spree!
-TEXTCLIENT_MATOURNAMENT_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is in a killing spree!,[%s] %s is in a killing spree!
+TEXTCLIENT_MATOURNAMENT_KILLNOTIFICATION_KILLINGSPREE_STOP,[%s] %s killed [%s] %s and stopped his killing spree!,[%s]%sが[%s]%sを倒し、連続撃破を止めた！
+TEXTCLIENT_MATOURNAMENT_KILLNOTIFICATION_KILLINGSPREE,[%s] %s is in a killing spree!,[%s]%sが連続撃破中！
 TEXTCLIENT_MATOURNAMENT_CANTTELEPORT,You can't teleport in the match anymore. Match has started.,マッチ中にテレポートすることはできなくなりました。試合が始まりました。
-TEXTCLIENT_MATOURNAMENT_BETTING_RECEIVE,You have received the betting dividends.,You have received the betting dividends.
-TEXTCLIENT_MATOURNAMENT_BETTING_RECEIVE_FAIL,Failed to send the dividends. Check your state.,Failed to send the dividends. Check your state.
-TEXTCLIENT_MATOURNAMENT_BETTING_BET,You bet %s Penya to %s.,You bet %s Penya to %s.
-TEXTCLIENT_MATOURNAMENT_BETTING_BET_OTHER,You already bet other team.,You already bet other team.
-TEXTCLIENT_MATOURNAMENT_BETTING_NO_TIME,You can't bid at this time.,You can't bid at this time.
-TEXTCLIENT_MATOURNAMENT_BETTING_NO_GOLD,You have no Penya to collect.,You have no Penya to collect.
-TEXTCLIENT_MATOURNAMENT_REWARD_NORECORD,You have no participation or rewards to receive.,You have no participation or rewards to receive.
-TEXTCLIENT_MATOURNAMENT_REWARD,You have received a reward.,You have received a reward.
-TEXTCLIENT_MATOURNAMENT_REWARD_MAIL,You can't receive the reward. Check your mail.,You can't receive the reward. Check your mail.
-TEXTCLIENT_MATOURNAMENT_BETTING_PAYOUT_MAIL,Madrigal Tournament Betting Payout,Madrigal Tournament Betting Payout
-TEXTCLIENT_MATOURNAMENT_BETTING_PAYOUT,You receive betting's payout.,You receive betting's payout.
-TEXTCLIENT_MATOURNAMENT_BETTING_FAIL,Betting failed. Please try again.,Betting failed. Please try again.
-TEXTCLIENT_MATOURNAMENT_REGISTRATION_FAIL,Registration failed. Please try again.,Registration failed. Please try again.
-TEXTCLIENT_MATOURNAMENT_FAIL_ENTER,Unable to enter the Madrigal Tournament.,Unable to enter the Madrigal Tournament.
-TEXTCLIENT_ULTIMATE_JEWEL_POSSIBLE_ITEM,The item is not allowed to add jewel.,The item is not allowed to add jewel.
-TEXTCLIENT_ERROR_NOULTIMATEJEWEL,There is no space to put a ultimate jewel.,There is no space to put a ultimate jewel.
-TEXTCLIENT_REMOVE_ULTIMATE_JEWEL_ERROR,Only ultimate weapon equipped with jewel is available.,Only ultimate weapon equipped with jewel is available.
-TEXTCLIENT_REMOVEULTIMATEJEWEL_NOSELECTION,You need to select a jewel to remove!,You need to select a jewel to remove!
-TEXTCLIENT_REMOVEULTIMATEJEWEL_NOJEWEL,The slot you selected has no jewel in it !,The slot you selected has no jewel in it !
-TEXTCLIENT_ULTIMATE_JEWEL_REMOVE_SUCCESS,Your ultimate jewel has been removed succesfully.,Your ultimate jewel has been removed succesfully.
+TEXTCLIENT_MATOURNAMENT_BETTING_RECEIVE,You have received the betting dividends.,ベット配当金を受け取りました。
+TEXTCLIENT_MATOURNAMENT_BETTING_RECEIVE_FAIL,Failed to send the dividends. Check your state.,配当金の送付に失敗しました。状態をご確認ください。
+TEXTCLIENT_MATOURNAMENT_BETTING_BET,You bet %s Penya to %s.,%sペニャを%sに賭けました。
+TEXTCLIENT_MATOURNAMENT_BETTING_BET_OTHER,You already bet other team.,既に別のチームに賭けています。
+TEXTCLIENT_MATOURNAMENT_BETTING_NO_TIME,You can't bid at this time.,現在は賭けることができません。
+TEXTCLIENT_MATOURNAMENT_BETTING_NO_GOLD,You have no Penya to collect.,受け取れるペニャがありません。
+TEXTCLIENT_MATOURNAMENT_REWARD_NORECORD,You have no participation or rewards to receive.,参加記録または受け取れる報酬がありません。
+TEXTCLIENT_MATOURNAMENT_REWARD,You have received a reward.,報酬を受け取りました。
+TEXTCLIENT_MATOURNAMENT_REWARD_MAIL,You can't receive the reward. Check your mail.,報酬を受け取れません。メールをご確認ください。
+TEXTCLIENT_MATOURNAMENT_BETTING_PAYOUT_MAIL,Madrigal Tournament Betting Payout,マドリガルトーナメントベット配当金
+TEXTCLIENT_MATOURNAMENT_BETTING_PAYOUT,You receive betting's payout.,ベット配当金を受け取りました。
+TEXTCLIENT_MATOURNAMENT_BETTING_FAIL,Betting failed. Please try again.,ベットに失敗しました。もう一度お試しください。
+TEXTCLIENT_MATOURNAMENT_REGISTRATION_FAIL,Registration failed. Please try again.,登録に失敗しました。もう一度お試しください。
+TEXTCLIENT_MATOURNAMENT_FAIL_ENTER,Unable to enter the Madrigal Tournament.,マドリガルトーナメントに入場できません。
+TEXTCLIENT_ULTIMATE_JEWEL_POSSIBLE_ITEM,The item is not allowed to add jewel.,このアイテムにはジュエルを追加できません。
+TEXTCLIENT_ERROR_NOULTIMATEJEWEL,There is no space to put a ultimate jewel.,アルティマジュエルを入れる空きがありません。
+TEXTCLIENT_REMOVE_ULTIMATE_JEWEL_ERROR,Only ultimate weapon equipped with jewel is available.,ジュエルを装着したアルティマ武器のみ使用できます。
+TEXTCLIENT_REMOVEULTIMATEJEWEL_NOSELECTION,You need to select a jewel to remove!,取り外すジュエルを選択してください！
+TEXTCLIENT_REMOVEULTIMATEJEWEL_NOJEWEL,The slot you selected has no jewel in it !,選択したスロットにはジュエルが入っていません！
+TEXTCLIENT_ULTIMATE_JEWEL_REMOVE_SUCCESS,Your ultimate jewel has been removed succesfully.,アルティマジュエルを取り外しました。
 TEXTCLIENT_COMPOSEJEWEL_SUCCESS,You received %s.,%sを獲得しました。
-TEXTCLIENT_ERROR_SAMEKIND_JEWEL,You can only attach one of each kind of jewel or rune.,You can only attach one of each kind of jewel or rune.
-TEXTCLIENT_COMPOSEJEWEL_FAIL,Fusion failed. Returned %d %s.,Fusion failed. Returned %d %s.
-TEXTCLIENT_COMPOSEJEWEL_REGISTER_SAMEKIND,Only the same jewel can be registered.,Only the same jewel can be registered.
-TEXTCLIENT_MANUFACTURE_ULTIMATEJEWEL_SUCCESS,Ultimate jewel creation successful!,Ultimate jewel creation successful!
-TEXTCLIENT_MANUFACTURE_ULTIMATEJEWEL_FAIL,Ultimate jewel creation failed.,Ultimate jewel creation failed.
-TEXTCLIENT_COUPLENOTARGET,You must select a player first.,You must select a player first.
-TEXTCLIENT_COUPLE_REFUSE,Your proposal was refused.,Your proposal was refused.
-TEXTCLIENT_COUPLE_BREAKUP_REFUSE,Your request for break up was refused.,Your request for break up was refused.
-TEXTCLIENT_COUPLE_FORM,"You are now a couple, congratulations!","You are now a couple, congratulations!"
-TEXTCLIENT_COUPLE_NOTSINGLE,Your target is already in a couple.,Your target is already in a couple.
-TEXTCLIENT_COUPLE_ANNOUNCE,%s and %s have become a couple!,%s and %s have become a couple!
-TEXTCLIENT_COUPLE_SKILL,The couple skill %s has been used.,The couple skill %s has been used.
-TEXTCLIENT_COUPLE_SKILL_INUSE,You already have the %s skill active.,You already have the %s skill active.
-TEXTCLIENT_COUPLE_SKILL_NOPOINTS,You do not have enough points.,You do not have enough points.
-TEXTCLIENT_COUPLE_SKILL_NOPARTY,You must be in the same party to use this skill.,You must be in the same party to use this skill.
-TEXTCLIENT_COUPLE_REPLACE_RING,This will replace your current couple ring. Are you sure you would like to send this request to your partner?,This will replace your current couple ring. Are you sure you would like to send this request to your partner?
-TEXTCLIENT_COUPLE_NEW_RING,Your ring has been replaced!,Your ring has been replaced!
-TEXTCLIENT_COUPLE_SAME_RING,You are already using this ring.,You are already using this ring.
-TEXTCLIENT_COUPLE_MISSING,You must be in a couple to use this item.,You must be in a couple to use this item.
-TEXTCLIENT_COUPLE_QUESTEXP,Your couple has gained experience!,Your couple has gained experience!
-TEXTCLIENT_COUPLE_NOTITLE,You must be in a couple to use this title.,You must be in a couple to use this title.
-TEXTCLIENT_COUPLE_BREAKUP_DEADLINE,The break up request was not answered. Forceful break up notification timer has begun.,The break up request was not answered. Forceful break up notification timer has begun.
-TEXTCLIENT_COUPLE_MAX_POINTS,Your couple cannot exceed the maximum skill points.,Your couple cannot exceed the maximum skill points.
-TEXTCLIENT_COUPLE_CHEER_SEND,You have cheered your partner.,You have cheered your partner.
-TEXTCLIENT_COUPLE_CHEER_REC,You have been cheered by your partner.,You have been cheered by your partner.
-TEXTCLIENT_COUPLE_MINLEVEL,You and your target must both be at least level %d.,You and your target must both be at least level %d.
-TEXTCLIENT_COUPLE_COOLDOWN,You need to wait %s to form a couple with this player.,You need to wait %s to form a couple with this player.
-TEXTCLIENT_COUPLE_PROPOSAL_SENT,You have sent a proposal!,You have sent a proposal!
-TEXTCLIENT_COMPOSE_RAINBOWJEWEL_FAIL,Composing rainbow jewel failed.,Composing rainbow jewel failed.
-TEXTCLIENT_DISMANTLE_RAINBOWJEWEL_SUCCESS,Dismantle rainbow jewel succeed.,Dismantle rainbow jewel succeed.
-TEXTCLIENT_DISMANTLE_RAINBOWJEWEL_FAIL,Dismantle rainbow jewel failed.,Dismantle rainbow jewel failed.
-TEXTCLIENT_HOUSINGWARDROBE_NPCNOTFOUND,The NPC you intended to edit does not exist in your house!,The NPC you intended to edit does not exist in your house!
-TEXTCLIENT_HOUSINGWARDROBE_ITEMNOTFOUND,The item you intented to equip is not in your wardrobe!,The item you intented to equip is not in your wardrobe!
-TEXTCLIENT_HOUSINGWARDROBE_ITEMALREADYUSED,There is already an NPC using that item!,There is already an NPC using that item!
-TEXTCLIENT_HOUSINGEQUIP_NORIGHTS,You don't have permission to edit the equipment of that NPC.,You don't have permission to edit the equipment of that NPC.
-TEXTCLIENT_HOUSINGINVENTORY_NORIGHTS,You don't have permission to edit the inventory of this house.,You don't have permission to edit the inventory of this house.
-TEXTCLIENT_HOUSINGINVENTORY_WRONGITEM,You can only put pets or eggs in the house pet inventory.,You can only put pets or eggs in the house pet inventory.
-TEXTCLIENT_HOUSEOBJECTS_PETEXIST,This pet already exists in the house.,This pet already exists in the house.
-TEXTCLIENT_HOUSINGPET_SPAWNED,You need to remove that pet before taking it out of the pet inventory!,You need to remove that pet before taking it out of the pet inventory!
-TEXTCLIENT_PETTRAINING_MAXLEVEL,This pet has already reached its maximum experience!,This pet has already reached its maximum experience!
-TEXTCLIENT_PETTRAINING_WRONGPET,This trainer can't accept that pet.,This trainer can't accept that pet.
-TEXTCLIENT_HOUSINGINVENTORY_FULL,Pet inventory is full!,Pet inventory is full!
-TEXTCLIENT_PETTRAINING_PETINUSE,You need to remove that pet from the field before training it!,You need to remove that pet from the field before training it!
-TEXTCLIENT_PETTRAINING_NAME,[Training],[Training]
-TEXTCLIENT_PETTRAINING_COMPLETE,Trainer %s has completed your pet training!,Trainer %s has completed your pet training!
-TEXTCLIENT_HOUSEPETSLOTS_MAX,You have already unlocked the maximum pet inventory slots!,You have already unlocked the maximum pet inventory slots!
-TEXTCLIENT_PLAYERHOUSEPETSLOTS_SUCCESS,You have successfully unlocked a new pet inventory slot for your house!,You have successfully unlocked a new pet inventory slot for your house!
-TEXTCLIENT_GUILDHOUSEPETSLOTS_NOGUILD,You need a guild to use this scroll!,You need a guild to use this scroll!
-TEXTCLIENT_GUILDHOUSEPETSLOTS_SUCCESS,"You have successfully unlocked a new pet inventory slot for the guild ship. If you do not have a house yet, it will be applied to your future houses.","You have successfully unlocked a new pet inventory slot for the guild ship. If you do not have a house yet, it will be applied to your future houses."
-TEXTCLIENT_COUPLE_MOTION,You must be in a level %d couple to use this emote.,You must be in a level %d couple to use this emote.
-TEXTCLIENT_COUPLE_MOTION_NOTARGET,You must select your partner in order to request this emote.,You must select your partner in order to request this emote.
-TEXTCLIENT_COUPLE_MOTION_REFUSE,Your partner refused to perform the emote.,Your partner refused to perform the emote.
-TEXTCLIENT_COUPLE_MOTION_RANGE,You are too far away from each other to perform this emote.,You are too far away from each other to perform this emote.
-TEXTCLIENT_APP_LIFE,Life Skills,Life Skills
-TEXTCLIENT_GATHERING_EQUIP,You need to equip a(n) %s.,You need to equip a(n) %s.
-TEXTCLIENT_GATHERING_EQUIP_CHECK,Please check the correct tool.,Please check the correct tool.
-TEXTCLIENT_GATHERING_FAIL,Gathering failed.,Gathering failed.
-TEXTCLIENT_GATHERING_HOE,hoe,hoe
-TEXTCLIENT_GATHERING_AXE,axe,axe
-TEXTCLIENT_GATHERING_PICKAXE,pickaxe,pickaxe
-TEXTCLIENT_GATHERING_FISHING_FAIL,Fishing failed.,Fishing failed.
-TEXTCLIENT_PROPINTERACTION_MAXUSE,Too many players are using this prop. Please try again later.,Too many players are using this prop. Please try again later.
-TEXTCLIENT_GATHERING_TOOL_REPAIR,Repaired %s for %s points.,Repaired %s for %s points.
-TEXTCLIENT_CHANGE_LIFE_MASTERY_EXPERT_TIME_FAIL,You cannot change your expertise yet.,You cannot change your expertise yet.
-TEXTCLIENT_CHANGE_LIFE_MASTERY_EXPERT_SUCCESS,Successfully changed your expertise.,Successfully changed your expertise.
-TEXTCLIENT_PRODUCTIONREDUCTION_FAIL,Failed to use the production reduction item. Please check your production status.,Failed to use the production reduction item. Please check your production status.
-TEXTCLIENT_PRODUCTION_FAIL_INGREDIENT_COUNT,You do not have enough ingredients.,You do not have enough ingredients.
-TEXTCLIENT_PRODUCTION_FAIL_CHECK_ITEM,Unable to check your ingredients.,Unable to check your ingredients.
-TEXTCLIENT_PRODUCTION_FAIL_ALREADY,You are already producing this item.,You are already producing this item.
-TEXTCLIENT_PROUCTIONREDUCTION_SUCCESS,The production time has been reduced by %d minutes.,The production time has been reduced by %d minutes.
-TEXTCLIENT_WANDERINGSHOPRENEWAL_SUCCESS,Wondering shop inventory renewed successfully.,Wondering shop inventory renewed successfully.
-TEXTCLIENT_LIFEMASTERYRANKINGREWARD_FAIL_INVENTORY,"No space in inventory, %d empty slots needed.","No space in inventory, %d empty slots needed."
-TEXTCLIENT_FISHING_FAIL_NOWATER,You can only fish near a body of water.,You can only fish near a body of water.
-TEXTCLIENT_FISHING_FAIL_NOROD,You need to equip a fishing rod.,You need to equip a fishing rod.
-TEXTCLIENT_FISHING_FAIL_BROKENROD,Your fishing rod must be repaired.,Your fishing rod must be repaired.
-TEXTCLIENT_FISHING_FAIL_BAIT,Not enough bait.,Not enough bait.
-TEXTCLIENT_FISHING_FAIL,You are unable to fish.,You are unable to fish.
-TEXTCLIENT_LIFEMASTERY_NEED_SKILL,You do not have the %s skill. You must complete the quest from [Life Master] Livi.,You do not have the %s skill. You must complete the quest from [Life Master] Livi.
-TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_MASTERYPOINTS,You lack enough mastery points.,You lack enough mastery points.
-TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_TITLE,You cannot produce this item without the required title.,You cannot produce this item without the required title.
-TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_INGREDIENT,You need to add the correct ingredients.,You need to add the correct ingredients.
-TEXTCLIENT_REPAIR_FAIL_FULLDURATION,This item does not require repairing.,This item does not require repairing.
-TEXTCLIENT_PRODUCTUPGRADE_FAIL,Product upgrade failed.,Product upgrade failed.
-TEXTCLIENT_PRODUCTUPGRADE_SUCCESS,Product upgrade successful!,Product upgrade successful!
-TEXTCLIENT_PRODUCTION_RECIPE_UNLOCK,%s's recipe has been unlocked.,%s's recipe has been unlocked.
-TEXTCLIENT_BUFF_ITEM_NOTUSE_STACK,You cannot stack this item anymore. This item can only be stacked %d times.,You cannot stack this item anymore. This item can only be stacked %d times.
-TEXTCLIENT_FISHING_FAIL_BAIT_INDEX,Can't find bait.,Can't find bait.
-TEXTCLIENT_LIFESKILL_NOT_LEARN,You have not learned the required skill yet.,You have not learned the required skill yet.
-TEXTCLIENT_LIFEMASTERY_RANKING_REWARD_RECEIVE,You have received %s as a reward for your life mastery ranking.,You have received %s as a reward for your life mastery ranking.
-TEXTCLIENT_LIFEMASTERY_RANKING_REWARD_FAIL,Could not send life mastery ranking reward.,Could not send life mastery ranking reward.
-TEXTCLIENT_LIFESTYLE_NOGOLD,Not enough Penya.,Not enough Penya.
-TEXTCLIENT_FISHING_FAIL_DIFF_POS,Fishing failed. Please move to a different spot and try again.,Fishing failed. Please move to a different spot and try again.
-TEXTCLIENT_COUPLEHOUSING_BUYSUCCESS,You successfully setup your couple house.,You successfully setup your couple house.
-TEXTCLIENT_COUPLEHOUSING_NOTOWN,You currently have no couple house yet.,You currently have no couple house yet.
-TEXTCLIENT_PROPINTERACTION_TOOFAR,You are too far.,You are too far.
-TEXTCLIENT_HOUSINGINVENTORY_NOPET,You need to use that pet at least once before putting it in the pet inventory.,You need to use that pet at least once before putting it in the pet inventory.
-TEXTCLIENT_HOUSINGINVENTORY_NOEGG,You cannot put eggs in the pet inventory.,You cannot put eggs in the pet inventory.
-TEXTCLIENT_RAINBOWRACE_MAX_INVITEES,You have exceeded the maximum number of invitees.,You have exceeded the maximum number of invitees.
-TEXTCLIENT_MATOURNAMENT_ENTRYSTART,The entrance time for the tournament match is now.,The entrance time for the tournament match is now.
-TEXTCLIENT_SWITCHEQUIP_USEATTACK,You can't use an equipment preset while attacking.,You can't use an equipment preset while attacking.
-TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_1,There are currently no races available to enter.,There are currently no races available to enter.
-TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_2,You are not a registered player.,You are not a registered player.
-TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_3,You cannot enter on the current channel.,You cannot enter on the current channel.
-TEXTCLIENT_MAIL_ITEM_PRODUCT_OVER,Product %s cannot be stored in the inventory or the bank if it exceeds %d items.,Product %s cannot be stored in the inventory or the bank if it exceeds %d items.
-TEXTCLIENT_HARVEST_NOTREADY,You can't harvest this now.,You can't harvest this now.
-TEXTCLIENT_HARVEST_NORIGHTS,You can't harvest this here.,You can't harvest this here.
-TEXTCLIENT_MOTION_REQQUEST,You must complete the quest %s to use this emote.,You must complete the quest %s to use this emote.
-TEXTCLIENT_USEITEM_PVP,You cannot use this item in a PvP setting.,You cannot use this item in a PvP setting.
-TEXTCLIENT_MOTION_ACTIVE,You can now use the emote %s!,You can now use the emote %s!
-TEXTCLIENT_MOTION_EXPIRE,The emote %s has expired.,The emote %s has expired.
-TEXTCLIENT_BLESSING_NOREMOVEFREE,You can't remove a Blessing of the Demon!,You can't remove a Blessing of the Demon!
-TEXTCLIENT_BATTLEPASS_REQUIRED2,This feature is only available with the Extended Flyff Pass.,This feature is only available with the Extended Flyff Pass.
-TEXTCLIENT_SEARCHSHOP_TPLIMIT,You already used all your daily teleports.,You already used all your daily teleports.
-TEXTCLIENT_SEARCHSHOP_CHANNEL,You cannot teleport to this shop because it is on a different channel.,You cannot teleport to this shop because it is on a different channel.
-TEXTCLIENT_HARVEST_COUNT,Harvests %d/%d,Harvests %d/%d
-TEXTCLIENT_HARVEST_COUNT_INFINITE,Infinite harvests,Infinite harvests
-TEXTCLIENT_PET_REROLL_TIER_SAME,The same level was rolled. No scrolls were consumed.,The same level was rolled. No scrolls were consumed.
-TEXTCLIENT_PET_REROLL_TIER_SUCCESS,The selected tier has been rerolled to a %d.,The selected tier has been rerolled to a %d.
-TEXTCLIENT_STATUE_BP,"Legendary fighters, imbued with the spirit of war.","Legendary fighters, imbued with the spirit of war."
-TEXTCLIENT_STATUE_RM,"Mystical leaders, channeling Rhisis' powers to command and protect their allies.","Mystical leaders, channeling Rhisis' powers to command and protect their allies."
-TEXTCLIENT_STATUE_JESTER,"Cunning tricksters, weaving illusions and chaos.","Cunning tricksters, weaving illusions and chaos."
-TEXTCLIENT_STATUE_RANGER,"Elusive hunters, guided by the spirits of nature.","Elusive hunters, guided by the spirits of nature."
-TEXTCLIENT_STATUE_KNIGHT,"Noble defenders, bound by honor and unbreakable resolve.","Noble defenders, bound by honor and unbreakable resolve."
-TEXTCLIENT_STATUE_BLADE,"Agile warriors, masters of swift, lethal strikes.","Agile warriors, masters of swift, lethal strikes."
-TEXTCLIENT_STATUE_ELE,"Powerful sorcerers, commanding the raw forces of nature.","Powerful sorcerers, commanding the raw forces of nature."
-TEXTCLIENT_STATUE_PSY,"Enigmatic mystics, harnessing the power of the mind.","Enigmatic mystics, harnessing the power of the mind."
-TEXTCLIENT_STATUE_VAGRANT,The start of all. You are Vagrant.,The start of all. You are Vagrant.
-TEXTCLIENT_PRODUCTION_RECIPE_UNLOCK_FAIL,Failed to reveal a recipe.,Failed to reveal a recipe.
-TEXTCLIENT_ARENA_LIMITED,You cannot use that in the arena.,You cannot use that in the arena.
-TEXTCLIENT_CANTUSEAWAKENING,You can't use an item while it's being awakened.,You can't use an item while it's being awakened.
-TEXTCLIENT_FLYERROR_NOFLY_FISHING,You can't fly when fishing.,You can't fly when fishing.
-TEXTCLIENT_COUPLEHOUSEPETSLOTS_SUCCESS,You have successfully unlocked a new pet inventory slot for your current or further couple house!,You have successfully unlocked a new pet inventory slot for your current or further couple house!
-TEXTCLIENT_WANDERING_SHOP_TICKET_FAIL,You can only use this item when the Wandering Shop is open.,You can only use this item when the Wandering Shop is open.
-TEXTCLIENT_VENDOR_RADIUS,"There is already a Private Shop at this position, please move a little bit.","There is already a Private Shop at this position, please move a little bit."
-TEXTCLIENT_NO_SPECTATE_WORLD,You cannot spectate in this world.,You cannot spectate in this world.
-TEXTCLIENT_NO_SPECTATE_PLAYER,You cannot spectate this player.,You cannot spectate this player.
-TEXTCLIENT_NO_SPECTATE_WAR,You cannot spectate right now.,You cannot spectate right now.
-TEXTCLIENT_NO_SPECTATE_SELF,You cannot spectate yourself.,You cannot spectate yourself.
-TEXTCLIENT_NO_SPECTATE_POWER,You do not have permission to spectate.,You do not have permission to spectate.
-TEXTCLIENT_START_SPECTATE,You are now spectating %s.,You are now spectating %s.
-UI_TOOLTIP_PICKUP_RANGE,Pickup boost range,Pickup boost range
-TEXTCLIENT_INVALIDORIGIN,Server refused the connection. Please make sure you are accessing from the official game page.,Server refused the connection. Please make sure you are accessing from the official game page.
-TEXTCLIENT_GATHERING_EVE_PICKAXE,[Event] Chroma Pickaxe,[Event] Chroma Pickaxe
-TEXTCLIENT_APP_SHADER_DEBUG,Shader Debug,Shader Debug
+TEXTCLIENT_ERROR_SAMEKIND_JEWEL,You can only attach one of each kind of jewel or rune.,同じ種類のジュエルまたはルーンは1つしか装着できません。
+TEXTCLIENT_COMPOSEJEWEL_FAIL,Fusion failed. Returned %d %s.,融合に失敗しました。%d %sが返却されました。
+TEXTCLIENT_COMPOSEJEWEL_REGISTER_SAMEKIND,Only the same jewel can be registered.,同じジュエルのみ登録できます。
+TEXTCLIENT_MANUFACTURE_ULTIMATEJEWEL_SUCCESS,Ultimate jewel creation successful!,アルティマジュエルの作成に成功しました！
+TEXTCLIENT_MANUFACTURE_ULTIMATEJEWEL_FAIL,Ultimate jewel creation failed.,アルティマジュエルの作成に失敗しました。
+TEXTCLIENT_COUPLENOTARGET,You must select a player first.,先にプレイヤーを選択してください。
+TEXTCLIENT_COUPLE_REFUSE,Your proposal was refused.,プロポーズが拒否されました。
+TEXTCLIENT_COUPLE_BREAKUP_REFUSE,Your request for break up was refused.,破局のリクエストが拒否されました。
+TEXTCLIENT_COUPLE_FORM,"You are now a couple, congratulations!",カップルになりました！おめでとうございます！
+TEXTCLIENT_COUPLE_NOTSINGLE,Your target is already in a couple.,対象は既にカップルです。
+TEXTCLIENT_COUPLE_ANNOUNCE,%s and %s have become a couple!,%sと%sがカップルになりました！
+TEXTCLIENT_COUPLE_SKILL,The couple skill %s has been used.,カップルスキル%sが使用されました。
+TEXTCLIENT_COUPLE_SKILL_INUSE,You already have the %s skill active.,%sスキルは既に発動中です。
+TEXTCLIENT_COUPLE_SKILL_NOPOINTS,You do not have enough points.,ポイントが不足しています。
+TEXTCLIENT_COUPLE_SKILL_NOPARTY,You must be in the same party to use this skill.,このスキルを使用するには、同じパーティーに所属している必要があります。
+TEXTCLIENT_COUPLE_REPLACE_RING,This will replace your current couple ring. Are you sure you would like to send this request to your partner?,現在のカップルリングが変更されます。パートナーにこのリクエストを送信してもよろしいですか？
+TEXTCLIENT_COUPLE_NEW_RING,Your ring has been replaced!,リングが変更されました！
+TEXTCLIENT_COUPLE_SAME_RING,You are already using this ring.,このリングは既に使用中です。
+TEXTCLIENT_COUPLE_MISSING,You must be in a couple to use this item.,このアイテムを使用するには、カップルである必要があります。
+TEXTCLIENT_COUPLE_QUESTEXP,Your couple has gained experience!,カップル経験値を獲得しました！
+TEXTCLIENT_COUPLE_NOTITLE,You must be in a couple to use this title.,この称号を使用するには、カップルである必要があります。
+TEXTCLIENT_COUPLE_BREAKUP_DEADLINE,The break up request was not answered. Forceful break up notification timer has begun.,破局リクエストへの応答がありませんでした。強制破局までのタイマーが開始されました。
+TEXTCLIENT_COUPLE_MAX_POINTS,Your couple cannot exceed the maximum skill points.,カップルスキルポイントは上限を超えられません。
+TEXTCLIENT_COUPLE_CHEER_SEND,You have cheered your partner.,パートナーを応援しました。
+TEXTCLIENT_COUPLE_CHEER_REC,You have been cheered by your partner.,パートナーから応援されました。
+TEXTCLIENT_COUPLE_MINLEVEL,You and your target must both be at least level %d.,あなたと対象は共にレベル%d以上である必要があります。
+TEXTCLIENT_COUPLE_COOLDOWN,You need to wait %s to form a couple with this player.,このプレイヤーとカップルになるには、%s待つ必要があります。
+TEXTCLIENT_COUPLE_PROPOSAL_SENT,You have sent a proposal!,プロポーズを送信しました！
+TEXTCLIENT_COMPOSE_RAINBOWJEWEL_FAIL,Composing rainbow jewel failed.,レインボージュエルの合成に失敗しました。
+TEXTCLIENT_DISMANTLE_RAINBOWJEWEL_SUCCESS,Dismantle rainbow jewel succeed.,レインボージュエルの解体に成功しました。
+TEXTCLIENT_DISMANTLE_RAINBOWJEWEL_FAIL,Dismantle rainbow jewel failed.,レインボージュエルの解体に失敗しました。
+TEXTCLIENT_HOUSINGWARDROBE_NPCNOTFOUND,The NPC you intended to edit does not exist in your house!,編集しようとしたNPCはあなたの家に存在しません！
+TEXTCLIENT_HOUSINGWARDROBE_ITEMNOTFOUND,The item you intented to equip is not in your wardrobe!,装備しようとしたアイテムがワードローブにありません！
+TEXTCLIENT_HOUSINGWARDROBE_ITEMALREADYUSED,There is already an NPC using that item!,そのアイテムは既に他のNPCが使用中です！
+TEXTCLIENT_HOUSINGEQUIP_NORIGHTS,You don't have permission to edit the equipment of that NPC.,そのNPCの装備を編集する権限がありません。
+TEXTCLIENT_HOUSINGINVENTORY_NORIGHTS,You don't have permission to edit the inventory of this house.,この家のインベントリを編集する権限がありません。
+TEXTCLIENT_HOUSINGINVENTORY_WRONGITEM,You can only put pets or eggs in the house pet inventory.,ハウスペットインベントリにはペットまたは卵のみ入れられます。
+TEXTCLIENT_HOUSEOBJECTS_PETEXIST,This pet already exists in the house.,このペットは既に家に存在します。
+TEXTCLIENT_HOUSINGPET_SPAWNED,You need to remove that pet before taking it out of the pet inventory!,ペットインベントリから取り出す前に、そのペットを撤去する必要があります！
+TEXTCLIENT_PETTRAINING_MAXLEVEL,This pet has already reached its maximum experience!,このペットは既に最大経験値に達しています！
+TEXTCLIENT_PETTRAINING_WRONGPET,This trainer can't accept that pet.,このトレーナーはそのペットを受け付けられません。
+TEXTCLIENT_HOUSINGINVENTORY_FULL,Pet inventory is full!,ペットインベントリがいっぱいです！
+TEXTCLIENT_PETTRAINING_PETINUSE,You need to remove that pet from the field before training it!,訓練する前に、そのペットをフィールドから外す必要があります！
+TEXTCLIENT_PETTRAINING_NAME,[Training],[訓練中]
+TEXTCLIENT_PETTRAINING_COMPLETE,Trainer %s has completed your pet training!,トレーナー%sがペットの訓練を完了しました！
+TEXTCLIENT_HOUSEPETSLOTS_MAX,You have already unlocked the maximum pet inventory slots!,ペットインベントリ枠は既に上限まで解放されています！
+TEXTCLIENT_PLAYERHOUSEPETSLOTS_SUCCESS,You have successfully unlocked a new pet inventory slot for your house!,家のペットインベントリ枠を新しく解放しました！
+TEXTCLIENT_GUILDHOUSEPETSLOTS_NOGUILD,You need a guild to use this scroll!,この巻物を使用するにはギルドが必要です！
+TEXTCLIENT_GUILDHOUSEPETSLOTS_SUCCESS,"You have successfully unlocked a new pet inventory slot for the guild ship. If you do not have a house yet, it will be applied to your future houses.",ギルド船のペットインベントリ枠を新しく解放しました！家をまだ所有していない場合は、今後所有する家に適用されます。
+TEXTCLIENT_COUPLE_MOTION,You must be in a level %d couple to use this emote.,このエモートを使用するには、カップルレベル%d以上である必要があります。
+TEXTCLIENT_COUPLE_MOTION_NOTARGET,You must select your partner in order to request this emote.,このエモートをリクエストするには、パートナーを選択する必要があります。
+TEXTCLIENT_COUPLE_MOTION_REFUSE,Your partner refused to perform the emote.,パートナーがエモートの実行を拒否しました。
+TEXTCLIENT_COUPLE_MOTION_RANGE,You are too far away from each other to perform this emote.,このエモートを行うには、パートナーとの距離が離れすぎています。
+TEXTCLIENT_APP_LIFE,Life Skills,ライフスキル
+TEXTCLIENT_GATHERING_EQUIP,You need to equip a(n) %s.,%sを装備する必要があります。
+TEXTCLIENT_GATHERING_EQUIP_CHECK,Please check the correct tool.,正しい道具かご確認ください。
+TEXTCLIENT_GATHERING_FAIL,Gathering failed.,採取に失敗しました。
+TEXTCLIENT_GATHERING_HOE,hoe,鍬
+TEXTCLIENT_GATHERING_AXE,axe,斧
+TEXTCLIENT_GATHERING_PICKAXE,pickaxe,つるはし
+TEXTCLIENT_GATHERING_FISHING_FAIL,Fishing failed.,釣りに失敗しました。
+TEXTCLIENT_PROPINTERACTION_MAXUSE,Too many players are using this prop. Please try again later.,このオブジェクトは多くのプレイヤーが使用中です。しばらくしてから再度お試しください。
+TEXTCLIENT_GATHERING_TOOL_REPAIR,Repaired %s for %s points.,%sを%sポイント修理しました。
+TEXTCLIENT_CHANGE_LIFE_MASTERY_EXPERT_TIME_FAIL,You cannot change your expertise yet.,まだ専門分野を変更できません。
+TEXTCLIENT_CHANGE_LIFE_MASTERY_EXPERT_SUCCESS,Successfully changed your expertise.,専門分野の変更が完了しました。
+TEXTCLIENT_PRODUCTIONREDUCTION_FAIL,Failed to use the production reduction item. Please check your production status.,製作時間短縮アイテムの使用に失敗しました。製作状況をご確認ください。
+TEXTCLIENT_PRODUCTION_FAIL_INGREDIENT_COUNT,You do not have enough ingredients.,材料が不足しています。
+TEXTCLIENT_PRODUCTION_FAIL_CHECK_ITEM,Unable to check your ingredients.,材料を確認できません。
+TEXTCLIENT_PRODUCTION_FAIL_ALREADY,You are already producing this item.,このアイテムは既に製作中です。
+TEXTCLIENT_PROUCTIONREDUCTION_SUCCESS,The production time has been reduced by %d minutes.,製作時間が%d分短縮されました。
+TEXTCLIENT_WANDERINGSHOPRENEWAL_SUCCESS,Wondering shop inventory renewed successfully.,行商の品揃えが更新されました。
+TEXTCLIENT_LIFEMASTERYRANKINGREWARD_FAIL_INVENTORY,"No space in inventory, %d empty slots needed.",インベントリに空きがありません。%d個の空きスロットが必要です。
+TEXTCLIENT_FISHING_FAIL_NOWATER,You can only fish near a body of water.,水辺の近くでのみ釣りができます。
+TEXTCLIENT_FISHING_FAIL_NOROD,You need to equip a fishing rod.,釣り竿を装備する必要があります。
+TEXTCLIENT_FISHING_FAIL_BROKENROD,Your fishing rod must be repaired.,釣り竿を修理する必要があります。
+TEXTCLIENT_FISHING_FAIL_BAIT,Not enough bait.,餌が不足しています。
+TEXTCLIENT_FISHING_FAIL,You are unable to fish.,釣りができません。
+TEXTCLIENT_LIFEMASTERY_NEED_SKILL,You do not have the %s skill. You must complete the quest from [Life Master] Livi.,%sスキルを持っていません。[Life Master] Liviのクエストを完了する必要があります。
+TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_MASTERYPOINTS,You lack enough mastery points.,マスタリーポイントが不足しています。
+TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_TITLE,You cannot produce this item without the required title.,必要な称号がないと、このアイテムを製作できません。
+TEXTCLIENT_LIFEMASTERY_PROUDCTION_FAIL_INGREDIENT,You need to add the correct ingredients.,正しい材料を入れる必要があります。
+TEXTCLIENT_REPAIR_FAIL_FULLDURATION,This item does not require repairing.,このアイテムは修理の必要がありません。
+TEXTCLIENT_PRODUCTUPGRADE_FAIL,Product upgrade failed.,製品の強化に失敗しました。
+TEXTCLIENT_PRODUCTUPGRADE_SUCCESS,Product upgrade successful!,製品の強化に成功しました！
+TEXTCLIENT_PRODUCTION_RECIPE_UNLOCK,%s's recipe has been unlocked.,%sのレシピが解放されました。
+TEXTCLIENT_BUFF_ITEM_NOTUSE_STACK,You cannot stack this item anymore. This item can only be stacked %d times.,これ以上重ねられません。このアイテムは%d回までしか重ねられません。
+TEXTCLIENT_FISHING_FAIL_BAIT_INDEX,Can't find bait.,餌が見つかりません。
+TEXTCLIENT_LIFESKILL_NOT_LEARN,You have not learned the required skill yet.,必要なスキルをまだ習得していません。
+TEXTCLIENT_LIFEMASTERY_RANKING_REWARD_RECEIVE,You have received %s as a reward for your life mastery ranking.,ライフマスタリーランキングの報酬として%sを受け取りました。
+TEXTCLIENT_LIFEMASTERY_RANKING_REWARD_FAIL,Could not send life mastery ranking reward.,ライフマスタリーランキング報酬の送付に失敗しました。
+TEXTCLIENT_LIFESTYLE_NOGOLD,Not enough Penya.,ペニャが不足しています。
+TEXTCLIENT_FISHING_FAIL_DIFF_POS,Fishing failed. Please move to a different spot and try again.,釣りに失敗しました。場所を変えて再度お試しください。
+TEXTCLIENT_COUPLEHOUSING_BUYSUCCESS,You successfully setup your couple house.,カップルハウスの設置が完了しました。
+TEXTCLIENT_COUPLEHOUSING_NOTOWN,You currently have no couple house yet.,現在カップルハウスを所有していません。
+TEXTCLIENT_PROPINTERACTION_TOOFAR,You are too far.,距離が離れすぎています。
+TEXTCLIENT_HOUSINGINVENTORY_NOPET,You need to use that pet at least once before putting it in the pet inventory.,ペットインベントリに入れる前に、そのペットを一度使用する必要があります。
+TEXTCLIENT_HOUSINGINVENTORY_NOEGG,You cannot put eggs in the pet inventory.,ペットインベントリに卵は入れられません。
+TEXTCLIENT_RAINBOWRACE_MAX_INVITEES,You have exceeded the maximum number of invitees.,招待できる人数の上限を超えました。
+TEXTCLIENT_MATOURNAMENT_ENTRYSTART,The entrance time for the tournament match is now.,トーナメント試合への入場時間になりました。
+TEXTCLIENT_SWITCHEQUIP_USEATTACK,You can't use an equipment preset while attacking.,攻撃中は装備プリセットを使用できません。
+TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_1,There are currently no races available to enter.,現在参加可能なレースはありません。
+TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_2,You are not a registered player.,登録済みのプレイヤーではありません。
+TEXTCLIENT_RAINBOWRACE_TELEPORT_ERROR_3,You cannot enter on the current channel.,現在のチャンネルでは入場できません。
+TEXTCLIENT_MAIL_ITEM_PRODUCT_OVER,Product %s cannot be stored in the inventory or the bank if it exceeds %d items.,製品%sは%d個を超えるとインベントリまたは倉庫に保管できません。
+TEXTCLIENT_HARVEST_NOTREADY,You can't harvest this now.,現在収穫できません。
+TEXTCLIENT_HARVEST_NORIGHTS,You can't harvest this here.,ここでは収穫できません。
+TEXTCLIENT_MOTION_REQQUEST,You must complete the quest %s to use this emote.,このエモートを使用するには、クエスト%sを完了する必要があります。
+TEXTCLIENT_USEITEM_PVP,You cannot use this item in a PvP setting.,PvP中はこのアイテムを使用できません。
+TEXTCLIENT_MOTION_ACTIVE,You can now use the emote %s!,エモート%sが使用可能になりました！
+TEXTCLIENT_MOTION_EXPIRE,The emote %s has expired.,エモート%sの有効期限が切れました。
+TEXTCLIENT_BLESSING_NOREMOVEFREE,You can't remove a Blessing of the Demon!,悪魔の祝福は取り外せません！
+TEXTCLIENT_BATTLEPASS_REQUIRED2,This feature is only available with the Extended Flyff Pass.,この機能は拡張バトルパスでのみ利用できます。
+TEXTCLIENT_SEARCHSHOP_TPLIMIT,You already used all your daily teleports.,本日のテレポート回数をすべて使用しました。
+TEXTCLIENT_SEARCHSHOP_CHANNEL,You cannot teleport to this shop because it is on a different channel.,このショップは別のチャンネルにあるため、テレポートできません。
+TEXTCLIENT_HARVEST_COUNT,Harvests %d/%d,収穫回数：%d/%d
+TEXTCLIENT_HARVEST_COUNT_INFINITE,Infinite harvests,収穫回数無制限
+TEXTCLIENT_PET_REROLL_TIER_SAME,The same level was rolled. No scrolls were consumed.,同じレベルが出たため、巻物は消費されませんでした。
+TEXTCLIENT_PET_REROLL_TIER_SUCCESS,The selected tier has been rerolled to a %d.,選択したティアが%dに再抽選されました。
+TEXTCLIENT_STATUE_BP,"Legendary fighters, imbued with the spirit of war.",伝説の戦士、その身に宿るは戦の魂。
+TEXTCLIENT_STATUE_RM,"Mystical leaders, channeling Rhisis' powers to command and protect their allies.",神秘なる指導者、リシスの力を操り、仲間を導き守る。
+TEXTCLIENT_STATUE_JESTER,"Cunning tricksters, weaving illusions and chaos.",狡猾なる道化師、幻影と混沌を紡ぐ。
+TEXTCLIENT_STATUE_RANGER,"Elusive hunters, guided by the spirits of nature.",とらえがたき狩人、自然の精霊に導かれし者。
+TEXTCLIENT_STATUE_KNIGHT,"Noble defenders, bound by honor and unbreakable resolve.",気高き守護者、名誉と不屈の意志に生きる。
+TEXTCLIENT_STATUE_BLADE,"Agile warriors, masters of swift, lethal strikes.",俊敏なる戦士、迅速にして必殺の一撃を極める。
+TEXTCLIENT_STATUE_ELE,"Powerful sorcerers, commanding the raw forces of nature.",強大なる魔導士、自然の猛威を操る。
+TEXTCLIENT_STATUE_PSY,"Enigmatic mystics, harnessing the power of the mind.",謎めきし神秘家、心の力を我がものとする。
+TEXTCLIENT_STATUE_VAGRANT,The start of all. You are Vagrant.,すべての始まり。あなたは放浪者。
+TEXTCLIENT_PRODUCTION_RECIPE_UNLOCK_FAIL,Failed to reveal a recipe.,レシピの解放に失敗しました。
+TEXTCLIENT_ARENA_LIMITED,You cannot use that in the arena.,アリーナ内ではそれを使用できません。
+TEXTCLIENT_CANTUSEAWAKENING,You can't use an item while it's being awakened.,覚醒処理中はアイテムを使用できません。
+TEXTCLIENT_FLYERROR_NOFLY_FISHING,You can't fly when fishing.,釣り中は飛行できません。
+TEXTCLIENT_COUPLEHOUSEPETSLOTS_SUCCESS,You have successfully unlocked a new pet inventory slot for your current or further couple house!,現在または今後のカップルハウスのペットインベントリ枠を新しく解放しました！
+TEXTCLIENT_WANDERING_SHOP_TICKET_FAIL,You can only use this item when the Wandering Shop is open.,このアイテムは行商が開いている時のみ使用できます。
+TEXTCLIENT_VENDOR_RADIUS,"There is already a Private Shop at this position, please move a little bit.",この位置にはすでに個人商店があります。少し移動してください。
+TEXTCLIENT_NO_SPECTATE_WORLD,You cannot spectate in this world.,このワールドでは観戦できません。
+TEXTCLIENT_NO_SPECTATE_PLAYER,You cannot spectate this player.,このプレイヤーは観戦できません。
+TEXTCLIENT_NO_SPECTATE_WAR,You cannot spectate right now.,現在は観戦できません。
+TEXTCLIENT_NO_SPECTATE_SELF,You cannot spectate yourself.,自分自身を観戦することはできません。
+TEXTCLIENT_NO_SPECTATE_POWER,You do not have permission to spectate.,観戦する権限がありません。
+TEXTCLIENT_START_SPECTATE,You are now spectating %s.,%sを観戦中です。
+UI_TOOLTIP_PICKUP_RANGE,Pickup boost range,アイテム取得範囲
+TEXTCLIENT_INVALIDORIGIN,Server refused the connection. Please make sure you are accessing from the official game page.,サーバーが接続を拒否しました。公式ゲームページからアクセスしているかご確認ください。
+TEXTCLIENT_GATHERING_EVE_PICKAXE,[Event] Chroma Pickaxe,[イベント]クロマつるはし
+TEXTCLIENT_APP_SHADER_DEBUG,Shader Debug,シェーダーデバッグ
 TEXTCLIENT_APP_ACCOUNT,Account,アカウント
-TEXTCLIENT_NOT_ENOUGH_ITEM2,You need %d %s.,You need %d %s.
+TEXTCLIENT_NOT_ENOUGH_ITEM2,You need %d %s.,%d個の%sが必要です。
 TEXTCLIENT_ITEMPACK_UPGRADE_DESTROY,Item destroyed due to the failure.,失敗によりアイテムが破壊されました。
-TEXTCLIENT_ITEMPACK_UPGRADE_LEVELDOWN,Item downgraded due to the failure.,Item downgraded due to the failure.
-TEXTCLIENT_ITEMPACK_UPGRADE_LIMIT,This item has exceeded its upgrade attempt limit,This item has exceeded its upgrade attempt limit
-TEXTCLIENT_STATUE_MAXLEVEL,"A statue in the name of %s, the first maximum level, has been erected in Northern Flarine.","A statue in the name of %s, the first maximum level, has been erected in Northern Flarine."
-TEXTCLIENT_STATUE_MAXUPGRADE,"A statue in the name of %s, the first maximum upgrader, has been erected in Northern Flarine.","A statue in the name of %s, the first maximum upgrader, has been erected in Northern Flarine."
-TEXTCLIENT_ALERT_TIME,[%d hours have passed] Excessive gaming can interfere with normal daily life.,[%d hours have passed] Excessive gaming can interfere with normal daily life.
-TEXTCLIENT_SERVERNOTALLOWED,Your account is not allowed to access this server.,Your account is not allowed to access this server.
-TEXTCLIENT_STATUE_BASE01,A statue in the name of the first person to reach maximum level.,A statue in the name of the first person to reach maximum level.
-TEXTCLIENT_STATUE_BASE02,A statue in the name of the first person to reach maximum upgrade.,A statue in the name of the first person to reach maximum upgrade.
-TEXTCLIENT_UPGRADE_WRONG_MATERIAL,Invalid material item for upgrade.,Invalid material item for upgrade.
-TEXTCLIENT_NOT_ENTER_TIME,You cannot participate right now.,You cannot participate right now.
-TEXTCLIENT_NOT_ENTER_LEVEL,You can participate from level %d.,You can participate from level %d.
-TEXTCLIENT_EXIT_BOSSRAID_DUNGEON,The boss monster has been defeated. You will exit the dungeon in %d seconds.,The boss monster has been defeated. You will exit the dungeon in %d seconds.
+TEXTCLIENT_ITEMPACK_UPGRADE_LEVELDOWN,Item downgraded due to the failure.,強化失敗によりアイテムが降格しました。
+TEXTCLIENT_ITEMPACK_UPGRADE_LIMIT,This item has exceeded its upgrade attempt limit,このアイテムは強化試行回数の上限を超えています
+TEXTCLIENT_STATUE_MAXLEVEL,"A statue in the name of %s, the first maximum level, has been erected in Northern Flarine.",初めて最大レベルに到達した%sの名を刻んだ像が、フラリス北広場に建立されました。
+TEXTCLIENT_STATUE_MAXUPGRADE,"A statue in the name of %s, the first maximum upgrader, has been erected in Northern Flarine.",初めて最大強化に到達した%sの名を刻んだ像が、フラリス北広場に建立されました。
+TEXTCLIENT_ALERT_TIME,[%d hours have passed] Excessive gaming can interfere with normal daily life.,[%d時間が経過しました]過度なプレイは日常生活に支障をきたす恐れがあります。
+TEXTCLIENT_SERVERNOTALLOWED,Your account is not allowed to access this server.,このアカウントはこのサーバーへのアクセスが許可されていません。
+TEXTCLIENT_STATUE_BASE01,A statue in the name of the first person to reach maximum level.,最大レベルに初めて到達した者の名を刻んだ像。
+TEXTCLIENT_STATUE_BASE02,A statue in the name of the first person to reach maximum upgrade.,最大強化に初めて到達した者の名を刻んだ像。
+TEXTCLIENT_UPGRADE_WRONG_MATERIAL,Invalid material item for upgrade.,強化に使用できない素材アイテムです。
+TEXTCLIENT_NOT_ENTER_TIME,You cannot participate right now.,現在は参加できません。
+TEXTCLIENT_NOT_ENTER_LEVEL,You can participate from level %d.,レベル%dから参加できます。
+TEXTCLIENT_EXIT_BOSSRAID_DUNGEON,The boss monster has been defeated. You will exit the dungeon in %d seconds.,ボスモンスターを撃破しました。%d秒後にダンジョンから退出します。
 TEXTCLIENT_PVPMATCH_COLOR_1,Red Team,レッドチーム
 TEXTCLIENT_PVPMATCH_COLOR_2,Blue Team,ブルーチーム
 TEXTCLIENT_PVPMATCH_COLOR_3,Green Team,グリーンチーム
 TEXTCLIENT_PVPMATCH_COLOR_4,Yellow Team,イエローチーム
 TEXTCLIENT_PVPMATCH_KILL,[%s] %s,[%s] %s
-TEXTCLIENT_TRADE_BLOCKED,Item or Penya has been removed. Please wait.,Item or Penya has been removed. Please wait.
-TEXTCLIENT_MAIL_LEVEL,You must reach level %d to send a mail.,You must reach level %d to send a mail.
-TEXTCLIENT_MAILBOX_FAILED,Mail delivery failed due to recipient settings.,Mail delivery failed due to recipient settings.
-TEXTCLIENT_MAILBOX_BLOCKED,Mail delivery failed due to messenger settings.,Mail delivery failed due to messenger settings.
+TEXTCLIENT_TRADE_BLOCKED,Item or Penya has been removed. Please wait.,アイテムまたはペニャが削除されました。しばらくお待ちください。
+TEXTCLIENT_MAIL_LEVEL,You must reach level %d to send a mail.,メールを送信するにはレベル%dに到達する必要があります。
+TEXTCLIENT_MAILBOX_FAILED,Mail delivery failed due to recipient settings.,受信者の設定により、メールの配送に失敗しました。
+TEXTCLIENT_MAILBOX_BLOCKED,Mail delivery failed due to messenger settings.,メッセンジャー設定により、メールの配送に失敗しました。
 TEXTCLIENT_ITEM_RECEIVED,You have received %s x%d.,%s x%dを受け取りました。
-TEXTCLIENT_ADD_ATTRIBUTE_SUCCESS,Item has been upgraded.,Item has been upgraded.
-TEXTCLIENT_ADD_ATTRIBUTE_INVALID,This item is not upgradeable.,This item is not upgradeable.
-TEXTCLIENT_REQSKILLSTACKS,You do not have the required skill stacks to use this skill.,You do not have the required skill stacks to use this skill.
-TEXTCLIENT_MAX_TRAPS,You cannot place another one of these traps yet.,You cannot place another one of these traps yet.
-TEXTCLIENT_TRAP_RANGE,You cannot place a trap here.,You cannot place a trap here.
-TEXTCLIENT_TRAP_TOOL,You do not have enough Trap Tool.,You do not have enough Trap Tool.
-TEXTCLIENT_ENCHANT_SAME_JEWEL_FAILED,Equipping the same jewel failed.,Equipping the same jewel failed.
-TEXTCLIENT_JEWELSYNTHESIS_NO,You do not have enough jewel or Penya for synthesis.,You do not have enough jewel or Penya for synthesis.
-TEXTCLIENT_JEWELSYNTHESIS_SUCCESS,Jewel synthesis succeeded!,Jewel synthesis succeeded!
-TEXTCLIENT_HEROQUEST_REQUIRED,This feature is only available with the Hero Quest.,This feature is only available with the Hero Quest.
-TEXTCLIENT_SKILLPAGE_COOLDOWN,You can swap skill pages in %d seconds.,You can swap skill pages in %d seconds.
-TEXTCLIENT_SKILLPAGE_NOSKILL,You cannot swap skill pages while using skills.,You cannot swap skill pages while using skills.
-TEXTCLIENT_CHGLEVEL_MASTER,You cannot use this item while on a master quest.,You cannot use this item while on a master quest.
-TEXTCLIENT_CHGLEVEL_JOBCHANGE,You cannot use this item while on a job change quest.,You cannot use this item while on a job change quest.
-TEXTCLIENT_MONSTER_ATTACK_ERROR_POSITION,You cannot attack the monster because you are not on the combat ground.,You cannot attack the monster because you are not on the combat ground.
-TEXTCLIENT_UPGRADEANNOUNCE_ULTIMATE,%s upgraded Ultimate %s to %s+%d!,%s upgraded Ultimate %s to %s+%d!
-TEXTCLIENT_PAYMENT_SUCCESS,Payment was successful!\nfCoins have been added to your account. ,Payment was successful!\nfCoins have been added to your account. 
-TEXTCLIENT_PAYMENT_ERROR,Unknown error during payment.\nPlease try again.,Unknown error during payment.\nPlease try again.
-TEXTCLIENT_EXP_RECOVER,You recovered the experience lost in the dungeon.,You recovered the experience lost in the dungeon.
-TEXTCLIENT_EXPBOX_OLDVERSION,You cannot use it because you already recovered experience by clearing the dungeon.,You cannot use it because you already recovered experience by clearing the dungeon.
-TEXTCLIENT_PARTYFAILREMOVE_DUNGEON,You cannot remove a member from your party while you are in the same dungeon.,You cannot remove a member from your party while you are in the same dungeon.
-TEXTCLIENT_PARTYFAILCHANGE_DUNGEON,You cannot transfer leadership to a party member who is not in the same dungeon.,You cannot transfer leadership to a party member who is not in the same dungeon.
-TEXTCLIENT_PARTYFAILLEAVE_DUNGEON,You cannot leave the party as a leader in the dungeon.,You cannot leave the party as a leader in the dungeon.
-TEXTCLIENT_BOSS_RAID_DUNGEON_ENDED,The instance dungeon has ended. Please try again in a moment.,The instance dungeon has ended. Please try again in a moment.
-TEXTCLIENT_BOSS_RAID_MAX_PLAYCOUNT,%s has no daily entries remaining.,%s has no daily entries remaining.
-TEXTCLIENT_BOSS_RAID_ANOTHER_DUNGEON,%s is already in another instance.,%s is already in another instance.
-TEXTCLIENT_MESSAGE_WARNING,Warning: '%s' is a regular player. Do not visit any website and never give out your credentials. The only official website is $WEBSITE$. Beware of scams and phishing websites.,Warning: '%s' is a regular player. Do not visit any website and never give out your credentials. The only official website is $WEBSITE$. Beware of scams and phishing websites.
-TEXTCLIENT_APP_DONATION,Donation,Donation
-TEXTCLIENT_APP_LORD,Lord Skills,Lord Skills
-TEXTCLIENT_DONATION_START,Donation event %s +%d%% started!,Donation event %s +%d%% started!
-TEXTCLIENT_DONATION_END,Donation event %s +%d% ended...,Donation event %s +%d% ended...
-TEXTCLIENT_DONATION_CONFIRM,You donated %s Penya to the %s event.,You donated %s Penya to the %s event.
-TEXTCLIENT_DONATION_MAIL,Congratulations for becoming the Lord of the week!,Congratulations for becoming the Lord of the week!
-TEXTCLIENT_DONATION_NOLORD,There is no Lord this week.,There is no Lord this week.
-TEXTCLIENT_DONATION_LORD,The Lord of the week is %s. Congratulations!,The Lord of the week is %s. Congratulations!
-TEXTCLIENT_MYSTCASTLE_DATA_PENDING,Server data synchronization in progress. Please try again shortly.,Server data synchronization in progress. Please try again shortly.
-TEXTCLIENT_MYSTCASTLE_INVALID_FLOOR,Invalid floor selection. Please try again.,Invalid floor selection. Please try again.
-TEXTCLIENT_MYSTCASTLE_LEVEL_TOO_LOW,Your level is too low to enter this floor.,Your level is too low to enter this floor.
-TEXTCLIENT_MYSTCASTLE_BLOCK_TIME,Ranking settlement in progress. Please try again later.,Ranking settlement in progress. Please try again later.
-TEXTCLIENT_MYSTCASTLE_INIT_FAILED,Failed to initialize the floor. Please try again.,Failed to initialize the floor. Please try again.
-TEXTCLIENT_MYSTCASTLE_FLOOR_TICKET_REQUIRED,A Mysterious Castle Retry Coupon is required to challenge this floor.,A Mysterious Castle Retry Coupon is required to challenge this floor.
-TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD,You received a reward for clearing a new floor.,You received a reward for clearing a new floor.
-TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD_MAIL,You can't receive the reward for clearing a new floor. Check your mail.,You can't receive the reward for clearing a new floor. Check your mail.
-TEXTCLIENT_MYSTCASTLE_USE_FLOOR_TICKET_FAIL,Unable to use the Mysterious Castle Retry Coupon.,Unable to use the Mysterious Castle Retry Coupon.
-TEXTCLIENT_LORDSKILLS_NOT,Only the Lord can use this menu.,Only the Lord can use this menu.
+TEXTCLIENT_ADD_ATTRIBUTE_SUCCESS,Item has been upgraded.,アイテムが強化されました。
+TEXTCLIENT_ADD_ATTRIBUTE_INVALID,This item is not upgradeable.,このアイテムは強化できません。
+TEXTCLIENT_REQSKILLSTACKS,You do not have the required skill stacks to use this skill.,このスキルを使用するために必要なスキルスタックがありません。
+TEXTCLIENT_MAX_TRAPS,You cannot place another one of these traps yet.,このトラップはまだ追加で設置できません。
+TEXTCLIENT_TRAP_RANGE,You cannot place a trap here.,ここにはトラップを設置できません。
+TEXTCLIENT_TRAP_TOOL,You do not have enough Trap Tool.,トラップツールが不足しています。
+TEXTCLIENT_ENCHANT_SAME_JEWEL_FAILED,Equipping the same jewel failed.,同種ジュエルの装着に失敗しました。
+TEXTCLIENT_JEWELSYNTHESIS_NO,You do not have enough jewel or Penya for synthesis.,合成に必要なジュエルまたはペニャが不足しています。
+TEXTCLIENT_JEWELSYNTHESIS_SUCCESS,Jewel synthesis succeeded!,ジュエル合成に成功しました！
+TEXTCLIENT_HEROQUEST_REQUIRED,This feature is only available with the Hero Quest.,この機能はヒーロークエストでのみ利用できます。
+TEXTCLIENT_SKILLPAGE_COOLDOWN,You can swap skill pages in %d seconds.,%d秒後にスキルページを切り替えられます。
+TEXTCLIENT_SKILLPAGE_NOSKILL,You cannot swap skill pages while using skills.,スキル使用中はスキルページを切り替えられません。
+TEXTCLIENT_CHGLEVEL_MASTER,You cannot use this item while on a master quest.,マスタークエスト中はこのアイテムを使用できません。
+TEXTCLIENT_CHGLEVEL_JOBCHANGE,You cannot use this item while on a job change quest.,転職クエスト中はこのアイテムを使用できません。
+TEXTCLIENT_MONSTER_ATTACK_ERROR_POSITION,You cannot attack the monster because you are not on the combat ground.,戦闘エリア外にいるため、モンスターを攻撃できません。
+TEXTCLIENT_UPGRADEANNOUNCE_ULTIMATE,%s upgraded Ultimate %s to %s+%d!,%sがアルティマ%sを%s+%dに強化しました！
+TEXTCLIENT_PAYMENT_SUCCESS,Payment was successful!\nfCoins have been added to your account. ,支払いが完了しました！\nfCoinがアカウントに追加されました。
+TEXTCLIENT_PAYMENT_ERROR,Unknown error during payment.\nPlease try again.,支払い中に不明なエラーが発生しました。\nもう一度お試しください。
+TEXTCLIENT_EXP_RECOVER,You recovered the experience lost in the dungeon.,ダンジョンで失った経験値を回復しました。
+TEXTCLIENT_EXPBOX_OLDVERSION,You cannot use it because you already recovered experience by clearing the dungeon.,ダンジョンクリアで既に経験値を回復済みのため使用できません。
+TEXTCLIENT_PARTYFAILREMOVE_DUNGEON,You cannot remove a member from your party while you are in the same dungeon.,同じダンジョン内ではパーティーメンバーを除名できません。
+TEXTCLIENT_PARTYFAILCHANGE_DUNGEON,You cannot transfer leadership to a party member who is not in the same dungeon.,同じダンジョンにいないパーティーメンバーにリーダー権限を譲渡できません。
+TEXTCLIENT_PARTYFAILLEAVE_DUNGEON,You cannot leave the party as a leader in the dungeon.,ダンジョン内ではリーダーとしてパーティーを離脱できません。
+TEXTCLIENT_BOSS_RAID_DUNGEON_ENDED,The instance dungeon has ended. Please try again in a moment.,インスタンスダンジョンが終了しました。しばらくしてから再度お試しください。
+TEXTCLIENT_BOSS_RAID_MAX_PLAYCOUNT,%s has no daily entries remaining.,%sの本日の入場回数が残っていません。
+TEXTCLIENT_BOSS_RAID_ANOTHER_DUNGEON,%s is already in another instance.,%sは既に別のインスタンスに入っています。
+TEXTCLIENT_MESSAGE_WARNING,Warning: '%s' is a regular player. Do not visit any website and never give out your credentials. The only official website is $WEBSITE$. Beware of scams and phishing websites.,警告：「%s」は一般プレイヤーです。いかなるウェブサイトにもアクセスせず、認証情報を教えないでください。公式サイトは$WEBSITE$のみです。詐欺やフィッシングサイトにご注意ください。
+TEXTCLIENT_APP_DONATION,Donation,寄付
+TEXTCLIENT_APP_LORD,Lord Skills,ロードスキル
+TEXTCLIENT_DONATION_START,Donation event %s +%d%% started!,寄付イベント%s +%d%%が開始しました！
+TEXTCLIENT_DONATION_END,Donation event %s +%d% ended...,寄付イベント%s +%d%が終了しました…
+TEXTCLIENT_DONATION_CONFIRM,You donated %s Penya to the %s event.,%sペニャを%sイベントに寄付しました。
+TEXTCLIENT_DONATION_MAIL,Congratulations for becoming the Lord of the week!,週間ロード就任おめでとうございます！
+TEXTCLIENT_DONATION_NOLORD,There is no Lord this week.,今週のロードはいません。
+TEXTCLIENT_DONATION_LORD,The Lord of the week is %s. Congratulations!,今週のロードは%sです。おめでとうございます！
+TEXTCLIENT_MYSTCASTLE_DATA_PENDING,Server data synchronization in progress. Please try again shortly.,サーバーデータ同期中です。しばらくしてから再度お試しください。
+TEXTCLIENT_MYSTCASTLE_INVALID_FLOOR,Invalid floor selection. Please try again.,無効な階層選択です。もう一度お試しください。
+TEXTCLIENT_MYSTCASTLE_LEVEL_TOO_LOW,Your level is too low to enter this floor.,レベルが低いため、この階層に入れません。
+TEXTCLIENT_MYSTCASTLE_BLOCK_TIME,Ranking settlement in progress. Please try again later.,ランキング集計中です。しばらくしてから再度お試しください。
+TEXTCLIENT_MYSTCASTLE_INIT_FAILED,Failed to initialize the floor. Please try again.,階層の初期化に失敗しました。もう一度お試しください。
+TEXTCLIENT_MYSTCASTLE_FLOOR_TICKET_REQUIRED,A Mysterious Castle Retry Coupon is required to challenge this floor.,この階層に挑戦するには、神秘の城リトライクーポンが必要です。
+TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD,You received a reward for clearing a new floor.,新しい階層をクリアした報酬を受け取りました。
+TEXTCLIENT_MYSTCASTLE_NEW_FLOOR_REWARD_MAIL,You can't receive the reward for clearing a new floor. Check your mail.,新しい階層クリアの報酬を受け取れません。メールをご確認ください。
+TEXTCLIENT_MYSTCASTLE_USE_FLOOR_TICKET_FAIL,Unable to use the Mysterious Castle Retry Coupon.,神秘の城リトライクーポンを使用できません。
+TEXTCLIENT_LORDSKILLS_NOT,Only the Lord can use this menu.,このメニューはロードのみ使用できます。
 TEXTCLIENT_DUNGEON_ESCORT_DIED,Your escort died.,護衛対象が死亡しました。


### PR DESCRIPTION
### Description
Translates the remaining untranslated entries in `Japanese/TextClient.csv` and `Japanese/Dialogs.csv`:
- A newly-added entry in `TextClient.csv`: `TEXTCLIENT_DUNGEON_ESCORT_DIED` ("Your escort died.").
- The remaining previously-untranslated entries across both files (system messages, dungeon/instance messages, donation event messages, Mysterious Castle messages, NPC dialogue, etc.).

Note: `Map.csv`'s corresponding new entry (`PROPMAP_TXT_100203`, Envy Depths Chaos) was already translated via a previously-merged PR, so no change was needed there.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project