### PR TITLE
[Japanese] Translate untranslated equipment set entries in EquipSets.csv

### DIFF
--- a/Japanese/EquipSets.csv
+++ b/Japanese/EquipSets.csv
@@ -147,10 +147,10 @@ PROPITEMETC_INC_000193,Quinox Set,アズリアエレメンターセット（M）
 PROPITEMETC_INC_000194,Quition Set,アズリアエレメンターセット(F)
 PROPITEMETC_INC_000195,FWC Golden Cryro Set,FWCゴールデン・クライロセット
 PROPITEMETC_INC_000196,FWC Golden Cyrent Set,FWCゴールデン・サイレントセット
-PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWCゴールデン・フォーベン セット
+PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWCゴールデン・フォーベンセット
 PROPITEMETC_INC_000198,FWC Golden Forrain Set,FWCゴールデン・フォーレインセット
 PROPITEMETC_INC_000199,FWC Golden Naneon Set,FWCゴールデン・ナネオンセット
-PROPITEMETC_INC_000200,FWC Golden Nanex Set,FWCゴールデン・ナネックス セット
+PROPITEMETC_INC_000200,FWC Golden Nanex Set,FWCゴールデン・ナネックスセット
 PROPITEMETC_INC_000201,FWC Golden Vizes Set,FWCゴールデン・バイスセット
 PROPITEMETC_INC_000202,FWC Golden Vizith Set,FWCゴールデン・ビジスセット
 PROPITEMETC_INC_000203,FWC Golden Keinos Set,FWCゴールデン・ケイノスセット
@@ -204,7 +204,7 @@ PROPITEMETC_INC_000319,Lypine Set,ライピーヌセット
 PROPITEMETC_INC_000320,FWC Golden Bileire Set,FWCゴールデン・ビレイアセット
 PROPITEMETC_INC_000321,FWC Golden Bilari Set,FWCゴールデン・ノウセット
 PROPITEMETC_INC_000322,FWC Golden Heraud Set,FWCゴールデン・ヘローセット
-PROPITEMETC_INC_000323,FWC Golden Herainn Set,FWCゴールデン・ヘレイン セット
+PROPITEMETC_INC_000323,FWC Golden Herainn Set,FWCゴールデン・ヘレインセット
 PROPITEMETC_INC_000324,FWC Golden Curio Set,FWCゴールデン・キュリオセット
 PROPITEMETC_INC_000325,FWC Golden Curena Set,FWCゴールデン・キュレナセット
 PROPITEMETC_INC_000326,FWC Golden Hainure Set,FWCゴールデン・ハイヌアセット
@@ -212,7 +212,7 @@ PROPITEMETC_INC_000327,FWC Golden Hanira Set,FWCゴールデン・ハニラセ�
 PROPITEMETC_INC_000328,FWC Golden Reine Set,FWCゴールデン・レーヌセット
 PROPITEMETC_INC_000329,FWC Golden Rayne Set,FWCゴールデン・レインセット
 PROPITEMETC_INC_000330,FWC Golden Roenier Set,FWCゴールデン・ロニアセット
-PROPITEMETC_INC_000331,FWC Golden Roelayne Set,FWCゴールデン・ローレイン セット
+PROPITEMETC_INC_000331,FWC Golden Roelayne Set,FWCゴールデン・ローレインセット
 PROPITEMETC_INC_000332,FWC Golden Reffiro Set,FWCゴールデン・レフィロセット
 PROPITEMETC_INC_000333,FWC Golden Rephira Set,FWCゴールデン・レフィラセット
 PROPITEMETC_INC_000334,FWC Golden Lippin Set,FWCゴールデン・リピンセット

--- a/Japanese/EquipSets.csv
+++ b/Japanese/EquipSets.csv
@@ -217,109 +217,109 @@ PROPITEMETC_INC_000332,FWC Golden Reffiro Set,FWCゴールデンレフィロセ�
 PROPITEMETC_INC_000333,FWC Golden Rephira Set,FWCゴールデンレフィラセット
 PROPITEMETC_INC_000334,FWC Golden Lippin Set,FWC ゴールデンリピンセット
 PROPITEMETC_INC_000335,FWC Golden Lypine Set,FWCゴールデンライパインセット
-PROPITEMETC_INC_000336,FWC 2025 Bloody Death Messenger’s Set (Winners),FWC 2025 Bloody Death Messenger’s Set (Winners)
-PROPITEMETC_INC_000337,FWC 2025 Golden Death Messenger’s Set (Finalists),FWC 2025 Golden Death Messenger’s Set (Finalists)
-PROPITEMETC_INC_000338,Runthiel Set,Runthiel Set
-PROPITEMETC_INC_000339,Runthien Set,Runthien Set
-PROPITEMETC_INC_000340,Rethanor Set,Rethanor Set
-PROPITEMETC_INC_000341,Rethanar Set,Rethanar Set
-PROPITEMETC_INC_000342,Zendric Set,Zendric Set
-PROPITEMETC_INC_000343,Zendricar Set,Zendricar Set
-PROPITEMETC_INC_000344,Khorviel Set,Khorviel Set
-PROPITEMETC_INC_000345,Khorvien Set,Khorvien Set
-PROPITEMETC_INC_000346,Zaythor Set,Zaythor Set
-PROPITEMETC_INC_000347,Zaythar Set,Zaythar Set
-PROPITEMETC_INC_000348,Vornithic Set,Vornithic Set
-PROPITEMETC_INC_000349,Vornithicar Set,Vornithicar Set
-PROPITEMETC_INC_000350,Dornith Set,Dornith Set
-PROPITEMETC_INC_000351,Dornyth Set,Dornyth Set
-PROPITEMETC_INC_000352,Quostrel Set,Quostrel Set
-PROPITEMETC_INC_000353,Quostren Set,Quostren Set
-PROPITEMETC_INC_000354,Chyrelle Set,Chyrelle Set
-PROPITEMETC_INC_000355,Chyrella Set,Chyrella Set
-PROPITEMETC_INC_000356,Noltrave Set,Noltrave Set
-PROPITEMETC_INC_000357,Noltrava Set,Noltrava Set
-PROPITEMETC_INC_000358,Frodral Set,Frodral Set
-PROPITEMETC_INC_000359,Frodrel Set,Frodrel Set
-PROPITEMETC_INC_000360,Treviron Set,Treviron Set
-PROPITEMETC_INC_000361,Treviran Set,Treviran Set
-PROPITEMETC_INC_000362,Lenvire Set,Lenvire Set
-PROPITEMETC_INC_000363,Lenvira Set,Lenvira Set
-PROPITEMETC_INC_000364,Ordelin Set,Ordelin Set
-PROPITEMETC_INC_000365,Ordelyn Set,Ordelyn Set
-PROPITEMETC_INC_000366,Tracien Set,Tracien Set
-PROPITEMETC_INC_000367,Tracior Set,Tracior Set
-PROPITEMETC_INC_000368,Lorvenic Set,Lorvenic Set
-PROPITEMETC_INC_000369,Lorvenicar Set,Lorvenicar Set
-PROPITEMETC_INC_000370,Etranor Set,Etranor Set
-PROPITEMETC_INC_000371,Etranar Set,Etranar Set
-PROPITEMETC_INC_000372,Lyzarel Set,Lyzarel Set
-PROPITEMETC_INC_000373,Lyzaren Set,Lyzaren Set
-PROPITEMETC_INC_000374,Exiran Set,Exiran Set
-PROPITEMETC_INC_000375,Exiren Set,Exiren Set
-PROPITEMETC_INC_000376,Haskrel Set,Haskrel Set
-PROPITEMETC_INC_000377,Haskren Set,Haskren Set
-PROPITEMETC_INC_000378,Kevric Set,Kevric Set
-PROPITEMETC_INC_000379,Kevricar Set,Kevricar Set
-PROPITEMETC_INC_000380,Brakiven Set,Brakiven Set
-PROPITEMETC_INC_000381,Brakivar Set,Brakivar Set
-PROPITEMETC_INC_000382,Zorect Set,Zorect Set
-PROPITEMETC_INC_000383,Zoracet Set,Zoracet Set
-PROPITEMETC_INC_000384,Sholthar Set,Sholthar Set
-PROPITEMETC_INC_000385,Sholtharen Set,Sholtharen Set
-PROPITEMETC_INC_000386,Ustamel Set,Ustamel Set
-PROPITEMETC_INC_000387,Ustamen Set,Ustamen Set
-PROPITEMETC_INC_000388,Obbric Set,Obbric Set
-PROPITEMETC_INC_000389,Obbricar Set,Obbricar Set
-PROPITEMETC_INC_000390,Yrenoth Set,Yrenoth Set
-PROPITEMETC_INC_000391,Yrenath Set,Yrenath Set
-PROPITEMETC_INC_000392,Vostran Set,Vostran Set
-PROPITEMETC_INC_000393,Vostren Set,Vostren Set
-PROPITEMETC_INC_000394,Virashon Set,Virashon Set
-PROPITEMETC_INC_000395,Verashan Set,Verashan Set
-PROPITEMETC_INC_000396,Menicor Set,Menicor Set
-PROPITEMETC_INC_000397,Maenicar Set,Maenicar Set
-PROPITEMETC_INC_000398,Tremiel Set,Tremiel Set
-PROPITEMETC_INC_000399,Tramien Set,Tramien Set
-PROPITEMETC_INC_000400,Calthien Set,Calthien Set
-PROPITEMETC_INC_000401,Calthior Set,Calthior Set
-PROPITEMETC_INC_000402,2026 FWC Golden Virashon Set,2026 FWC Golden Virashon Set
-PROPITEMETC_INC_000403,2026 FWC Golden Verashan Set,2026 FWC Golden Verashan Set
-PROPITEMETC_INC_000404,2026 FWC Golden Lenvire Set,2026 FWC Golden Lenvire Set
-PROPITEMETC_INC_000405,2026 FWC Golden Lenvira Set,2026 FWC Golden Lenvira Set
-PROPITEMETC_INC_000406,2026 FWC Golden Kevric Set,2026 FWC Golden Kevric Set
-PROPITEMETC_INC_000407,2026 FWC Golden Kevricar Set,2026 FWC Golden Kevricar Set
-PROPITEMETC_INC_000408,2026 FWC Golden Chyrelle Set,2026 FWC Golden Chyrelle Set
-PROPITEMETC_INC_000409,2026 FWC Golden Chyrella Set,2026 FWC Golden Chyrella Set
-PROPITEMETC_INC_000410,2026 FWC Golden Ustamel Set,2026 FWC Golden Ustamel Set
-PROPITEMETC_INC_000411,2026 FWC Golden Ustamen Set,2026 FWC Golden Ustamen Set
-PROPITEMETC_INC_000412,2026 FWC Golden Etranor Set,2026 FWC Golden Etranor Set
-PROPITEMETC_INC_000413,2026 FWC Golden Etranar Set,2026 FWC Golden Etranar Set
-PROPITEMETC_INC_000414,2026 FWC Golden Zaythor Set,2026 FWC Golden Zaythor Set
-PROPITEMETC_INC_000415,2026 FWC Golden Zaythar Set,2026 FWC Golden Zaythar Set
-PROPITEMETC_INC_000416,2026 FWC Golden Runthiel Set,2026 FWC Golden Runthiel Set
-PROPITEMETC_INC_000417,2026 FWC Golden Runthien Set,2026 FWC Golden Runthien Set
-PROPITEMETC_INC_000418,Celestial Phoenix Orange Set,Celestial Phoenix Orange Set
-PROPITEMETC_INC_000419,Celestial Phoenix Purple Set,Celestial Phoenix Purple Set
-PROPITEMETC_INC_000420,Celestial Phoenix Green Set,Celestial Phoenix Green Set
-PROPITEMETC_INC_000421,Celestial Phoenix Cyan Set,Celestial Phoenix Cyan Set
-PROPITEMETC_INC_000422,Celestial Phoenix Blue Set,Celestial Phoenix Blue Set
-PROPITEMETC_INC_000423,Celestial Phoenix Amethyst Set,Celestial Phoenix Amethyst Set
-PROPITEMETC_INC_000424,Celestial Phoenix Magenta Set,Celestial Phoenix Magenta Set
-PROPITEMETC_INC_000425,Celestial Phoenix Gold Set,Celestial Phoenix Gold Set
-PROPITEMETC_INC_000426,Primordial Runthiel Set,Primordial Runthiel Set
-PROPITEMETC_INC_000427,Primordial Runthien Set,Primordial Runthien Set
-PROPITEMETC_INC_000428,Primordial Zaythor Set,Primordial Zaythor Set
-PROPITEMETC_INC_000429,Primordial Zaythar Set,Primordial Zaythar Set
-PROPITEMETC_INC_000430,Primordial Chyrelle Set,Primordial Chyrelle Set
-PROPITEMETC_INC_000431,Primordial Chyrella Set,Primordial Chyrella Set
-PROPITEMETC_INC_000432,Primordial Lenvire Set,Primordial Lenvire Set
-PROPITEMETC_INC_000433,Primordial Lenvira Set,Primordial Lenvira Set
-PROPITEMETC_INC_000434,Primordial Etranor Set,Primordial Etranor Set
-PROPITEMETC_INC_000435,Primordial Etranar Set,Primordial Etranar Set
-PROPITEMETC_INC_000436,Primordial Kevric Set,Primordial Kevric Set
-PROPITEMETC_INC_000437,Primordial Kevricar Set,Primordial Kevricar Set
-PROPITEMETC_INC_000438,Primordial Ustamel Set,Primordial Ustamel Set
-PROPITEMETC_INC_000439,Primordial Ustamen Set,Primordial Ustamen Set
-PROPITEMETC_INC_000440,Primordial Virashon Set,Primordial Virashon Set
-PROPITEMETC_INC_000441,Primordial Verashan Set,Primordial Verashan Set
+PROPITEMETC_INC_000336,FWC 2025 Bloody Death Messenger’s Set (Winners),FWC2025ブラッディー・デスメッセンジャーセット（優勝者）
+PROPITEMETC_INC_000337,FWC 2025 Golden Death Messenger’s Set (Finalists),FWC2025ゴールデン・デスメッセンジャーセット（決勝進出者）
+PROPITEMETC_INC_000338,Runthiel Set,ランティエルセット
+PROPITEMETC_INC_000339,Runthien Set,ランティエンセット
+PROPITEMETC_INC_000340,Rethanor Set,レサノールセット
+PROPITEMETC_INC_000341,Rethanar Set,レサナーセット
+PROPITEMETC_INC_000342,Zendric Set,ゼンドリックセット
+PROPITEMETC_INC_000343,Zendricar Set,ゼンドリカーセット
+PROPITEMETC_INC_000344,Khorviel Set,コルヴィエルセット
+PROPITEMETC_INC_000345,Khorvien Set,コルヴィエンセット
+PROPITEMETC_INC_000346,Zaythor Set,ゼイソーセット
+PROPITEMETC_INC_000347,Zaythar Set,ゼイサーセット
+PROPITEMETC_INC_000348,Vornithic Set,ヴォルニシックセット
+PROPITEMETC_INC_000349,Vornithicar Set,ヴォルニシカーセット
+PROPITEMETC_INC_000350,Dornith Set,ドルニスセット
+PROPITEMETC_INC_000351,Dornyth Set,ドルニュスセット
+PROPITEMETC_INC_000352,Quostrel Set,クォストレルセット
+PROPITEMETC_INC_000353,Quostren Set,クォストレンセット
+PROPITEMETC_INC_000354,Chyrelle Set,シレルセット
+PROPITEMETC_INC_000355,Chyrella Set,シレラセット
+PROPITEMETC_INC_000356,Noltrave Set,ノルトレイヴセット
+PROPITEMETC_INC_000357,Noltrava Set,ノルトラヴァセット
+PROPITEMETC_INC_000358,Frodral Set,フロドラルセット
+PROPITEMETC_INC_000359,Frodrel Set,フロドレルセット
+PROPITEMETC_INC_000360,Treviron Set,トレヴィロンセット
+PROPITEMETC_INC_000361,Treviran Set,トレヴィランセット
+PROPITEMETC_INC_000362,Lenvire Set,レンヴィールセット
+PROPITEMETC_INC_000363,Lenvira Set,レンヴィラセット
+PROPITEMETC_INC_000364,Ordelin Set,オルデリンセット
+PROPITEMETC_INC_000365,Ordelyn Set,オルデリュンセット
+PROPITEMETC_INC_000366,Tracien Set,トラシエンセット
+PROPITEMETC_INC_000367,Tracior Set,トラシオールセット
+PROPITEMETC_INC_000368,Lorvenic Set,ロルヴェニックセット
+PROPITEMETC_INC_000369,Lorvenicar Set,ロルヴェニカーセット
+PROPITEMETC_INC_000370,Etranor Set,エトラノールセット
+PROPITEMETC_INC_000371,Etranar Set,エトラナーセット
+PROPITEMETC_INC_000372,Lyzarel Set,リザレルセット
+PROPITEMETC_INC_000373,Lyzaren Set,リザレンセット
+PROPITEMETC_INC_000374,Exiran Set,エクシランセット
+PROPITEMETC_INC_000375,Exiren Set,エクシレンセット
+PROPITEMETC_INC_000376,Haskrel Set,ハスクレルセット
+PROPITEMETC_INC_000377,Haskren Set,ハスクレンセット
+PROPITEMETC_INC_000378,Kevric Set,ケブリックセット
+PROPITEMETC_INC_000379,Kevricar Set,ケブリカーセット
+PROPITEMETC_INC_000380,Brakiven Set,ブラキヴェンセット
+PROPITEMETC_INC_000381,Brakivar Set,ブラキヴァーセット
+PROPITEMETC_INC_000382,Zorect Set,ゾレクトセット
+PROPITEMETC_INC_000383,Zoracet Set,ゾラセットセット
+PROPITEMETC_INC_000384,Sholthar Set,ショルサーセット
+PROPITEMETC_INC_000385,Sholtharen Set,ショルサレンセット
+PROPITEMETC_INC_000386,Ustamel Set,ウスタメルセット
+PROPITEMETC_INC_000387,Ustamen Set,ウスタメンセット
+PROPITEMETC_INC_000388,Obbric Set,オブリックセット
+PROPITEMETC_INC_000389,Obbricar Set,オブリカーセット
+PROPITEMETC_INC_000390,Yrenoth Set,イレノスセット
+PROPITEMETC_INC_000391,Yrenath Set,イレナスセット
+PROPITEMETC_INC_000392,Vostran Set,ヴォストランセット
+PROPITEMETC_INC_000393,Vostren Set,ヴォストレンセット
+PROPITEMETC_INC_000394,Virashon Set,ヴィラションセット
+PROPITEMETC_INC_000395,Verashan Set,ヴェラシャンセット
+PROPITEMETC_INC_000396,Menicor Set,メニコールセット
+PROPITEMETC_INC_000397,Maenicar Set,メニカーセット
+PROPITEMETC_INC_000398,Tremiel Set,トレミエルセット
+PROPITEMETC_INC_000399,Tramien Set,トラミエンセット
+PROPITEMETC_INC_000400,Calthien Set,カルシエンセット
+PROPITEMETC_INC_000401,Calthior Set,カルシオルセット
+PROPITEMETC_INC_000402,2026 FWC Golden Virashon Set,2026 FWCゴールデンヴィラションセット
+PROPITEMETC_INC_000403,2026 FWC Golden Verashan Set,2026 FWCゴールデンヴェラシャンセット
+PROPITEMETC_INC_000404,2026 FWC Golden Lenvire Set,2026 FWCゴールデンレンヴィールセット
+PROPITEMETC_INC_000405,2026 FWC Golden Lenvira Set,2026 FWCゴールデンレンヴィラセット
+PROPITEMETC_INC_000406,2026 FWC Golden Kevric Set,2026 FWCゴールデンケブリックセット
+PROPITEMETC_INC_000407,2026 FWC Golden Kevricar Set,2026 FWCゴールデンケブリカーセット
+PROPITEMETC_INC_000408,2026 FWC Golden Chyrelle Set,2026 FWCゴールデンシレルセット
+PROPITEMETC_INC_000409,2026 FWC Golden Chyrella Set,2026 FWCゴールデンシレラセット
+PROPITEMETC_INC_000410,2026 FWC Golden Ustamel Set,2026 FWCゴールデンウスタメルセット
+PROPITEMETC_INC_000411,2026 FWC Golden Ustamen Set,2026 FWCゴールデンウスタメンセット
+PROPITEMETC_INC_000412,2026 FWC Golden Etranor Set,2026 FWCゴールデンエトラノールセット
+PROPITEMETC_INC_000413,2026 FWC Golden Etranar Set,2026 FWCゴールデンエトラナーセット
+PROPITEMETC_INC_000414,2026 FWC Golden Zaythor Set,2026 FWCゴールデンゼイソーセット
+PROPITEMETC_INC_000415,2026 FWC Golden Zaythar Set,2026 FWCゴールデンゼイサーセット
+PROPITEMETC_INC_000416,2026 FWC Golden Runthiel Set,2026 FWCゴールデンランティエルセット
+PROPITEMETC_INC_000417,2026 FWC Golden Runthien Set,2026 FWCゴールデンランティエンセット
+PROPITEMETC_INC_000418,Celestial Phoenix Orange Set,セレスティアルフェニックスオレンジセット
+PROPITEMETC_INC_000419,Celestial Phoenix Purple Set,セレスティアルフェニックスパープルセット
+PROPITEMETC_INC_000420,Celestial Phoenix Green Set,セレスティアルフェニックスグリーンセット
+PROPITEMETC_INC_000421,Celestial Phoenix Cyan Set,セレスティアルフェニックスシアンセット
+PROPITEMETC_INC_000422,Celestial Phoenix Blue Set,セレスティアルフェニックスブルーセット
+PROPITEMETC_INC_000423,Celestial Phoenix Amethyst Set,セレスティアルフェニックスアメジストセット
+PROPITEMETC_INC_000424,Celestial Phoenix Magenta Set,セレスティアルフェニックスマゼンタセット
+PROPITEMETC_INC_000425,Celestial Phoenix Gold Set,セレスティアルフェニックスゴールドセット
+PROPITEMETC_INC_000426,Primordial Runthiel Set,プリモーディアルランティエルセット
+PROPITEMETC_INC_000427,Primordial Runthien Set,プリモーディアルランティエンセット
+PROPITEMETC_INC_000428,Primordial Zaythor Set,プリモーディアルゼイソーセット
+PROPITEMETC_INC_000429,Primordial Zaythar Set,プリモーディアルゼイサーセット
+PROPITEMETC_INC_000430,Primordial Chyrelle Set,プリモーディアルシレルセット
+PROPITEMETC_INC_000431,Primordial Chyrella Set,プリモーディアルシレラセット
+PROPITEMETC_INC_000432,Primordial Lenvire Set,プリモーディアルレンヴィールセット
+PROPITEMETC_INC_000433,Primordial Lenvira Set,プリモーディアルレンヴィラセット
+PROPITEMETC_INC_000434,Primordial Etranor Set,プリモーディアルエトラノールセット
+PROPITEMETC_INC_000435,Primordial Etranar Set,プリモーディアルエトラナーセット
+PROPITEMETC_INC_000436,Primordial Kevric Set,プリモーディアルケブリックセット
+PROPITEMETC_INC_000437,Primordial Kevricar Set,プリモーディアルケブリカーセット
+PROPITEMETC_INC_000438,Primordial Ustamel Set,プリモーディアルウスタメルセット
+PROPITEMETC_INC_000439,Primordial Ustamen Set,プリモーディアルウスタメンセット
+PROPITEMETC_INC_000440,Primordial Virashon Set,プリモーディアルヴィラションセット
+PROPITEMETC_INC_000441,Primordial Verashan Set,プリモーディアルヴェラシャンセット

--- a/Japanese/EquipSets.csv
+++ b/Japanese/EquipSets.csv
@@ -264,7 +264,7 @@ PROPITEMETC_INC_000379,Kevricar Set,ケブリカーセット
 PROPITEMETC_INC_000380,Brakiven Set,ブラキヴェンセット
 PROPITEMETC_INC_000381,Brakivar Set,ブラキヴァーセット
 PROPITEMETC_INC_000382,Zorect Set,ゾレクトセット
-PROPITEMETC_INC_000383,Zoracet Set,ゾラセットセット
+PROPITEMETC_INC_000383,Zoracet Set,ゾラセトセット
 PROPITEMETC_INC_000384,Sholthar Set,ショルサーセット
 PROPITEMETC_INC_000385,Sholtharen Set,ショルサレンセット
 PROPITEMETC_INC_000386,Ustamel Set,ウスタメルセット

--- a/Japanese/EquipSets.csv
+++ b/Japanese/EquipSets.csv
@@ -145,22 +145,22 @@ PROPITEMETC_INC_000191,Peinn Set,アズリアサイキーパーセット（M）
 PROPITEMETC_INC_000192,Penel Set,アズリアサイキーパーセット(F)
 PROPITEMETC_INC_000193,Quinox Set,アズリアエレメンターセット（M）
 PROPITEMETC_INC_000194,Quition Set,アズリアエレメンターセット(F)
-PROPITEMETC_INC_000195,FWC Golden Cryro Set,FWCゴールデンクライロセット
-PROPITEMETC_INC_000196,FWC Golden Cyrent Set,FWCゴールデンサイレントセット
-PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWC ゴールデン フォーベン セット
-PROPITEMETC_INC_000198,FWC Golden Forrain Set,FWCゴールデンフォーレインセット
-PROPITEMETC_INC_000199,FWC Golden Naneon Set,FWCゴールデンナネオンセット
-PROPITEMETC_INC_000200,FWC Golden Nanex Set,FWC ゴールデン ナネックス セット
-PROPITEMETC_INC_000201,FWC Golden Vizes Set,FWC ゴールデンバイスセット
-PROPITEMETC_INC_000202,FWC Golden Vizith Set,FWCゴールデンビジスセット
-PROPITEMETC_INC_000203,FWC Golden Keinos Set,FWC ゴールデンケイノスセット
-PROPITEMETC_INC_000204,FWC Golden Keisan Set,FWC ゴールデンケイサンセット
-PROPITEMETC_INC_000205,FWC Golden Ouken Set,FWC ゴールデンオウケンセット
-PROPITEMETC_INC_000206,FWC Golden Oukest Set,FWCゴールデンオークストセット
-PROPITEMETC_INC_000207,FWC Golden Peinn Set,FWCゴールデンペインセット
-PROPITEMETC_INC_000208,FWC Golden Penel Set,FWCゴールデンペネルセット
-PROPITEMETC_INC_000209,FWC Golden Quinox Set,FWCゴールデンキノックスセット
-PROPITEMETC_INC_000210,FWC Golden Quition Set,FWCゴールデンクイションセット
+PROPITEMETC_INC_000195,FWC Golden Cryro Set,FWCゴールデン・クライロセット
+PROPITEMETC_INC_000196,FWC Golden Cyrent Set,FWCゴールデン・サイレントセット
+PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWC ゴールデン・フォーベン セット
+PROPITEMETC_INC_000198,FWC Golden Forrain Set,FWCゴールデン・フォーレインセット
+PROPITEMETC_INC_000199,FWC Golden Naneon Set,FWCゴールデン・ナネオンセット
+PROPITEMETC_INC_000200,FWC Golden Nanex Set,FWCゴールデン・ナネックス セット
+PROPITEMETC_INC_000201,FWC Golden Vizes Set,FWCゴールデン・バイスセット
+PROPITEMETC_INC_000202,FWC Golden Vizith Set,FWCゴールデン・ビジスセット
+PROPITEMETC_INC_000203,FWC Golden Keinos Set,FWCゴールデン・ケイノスセット
+PROPITEMETC_INC_000204,FWC Golden Keisan Set,FWCゴールデン・ケイサンセット
+PROPITEMETC_INC_000205,FWC Golden Ouken Set,FWCゴールデン・オウケンセット
+PROPITEMETC_INC_000206,FWC Golden Oukest Set,FWCゴールデン・オークストセット
+PROPITEMETC_INC_000207,FWC Golden Peinn Set,FWCゴールデン・ペインセット
+PROPITEMETC_INC_000208,FWC Golden Penel Set,FWCゴールデン・ペネルセット
+PROPITEMETC_INC_000209,FWC Golden Quinox Set,FWCゴールデン・キノックスセット
+PROPITEMETC_INC_000210,FWC Golden Quition Set,FWCゴールデン・クイションセット
 PROPITEMETC_INC_000211,Warbringer's Set,ウォーブリンガーセット
 PROPITEMETC_INC_000212,Sentinel's Set,センチネルセット
 PROPITEMETC_INC_000213,Spellweaver's Set,スペルウィーバーセット
@@ -201,22 +201,22 @@ PROPITEMETC_INC_000316,Reffiro Set,レフィーロセット
 PROPITEMETC_INC_000317,Rephira Set,レフィラセット
 PROPITEMETC_INC_000318,Lippin Set,リッピンセット
 PROPITEMETC_INC_000319,Lypine Set,ライピーヌセット
-PROPITEMETC_INC_000320,FWC Golden Bileire Set,FWCゴールデンビレイアセット
-PROPITEMETC_INC_000321,FWC Golden Bilari Set,FWCゴールデンノウセット
-PROPITEMETC_INC_000322,FWC Golden Heraud Set,FWCゴールデンヘローセット
-PROPITEMETC_INC_000323,FWC Golden Herainn Set,FWC ゴールデン ヘレイン セット
-PROPITEMETC_INC_000324,FWC Golden Curio Set,FWCゴールデンキュリオセット
-PROPITEMETC_INC_000325,FWC Golden Curena Set,FWCゴールデンキュレナセット
-PROPITEMETC_INC_000326,FWC Golden Hainure Set,FWCゴールデンハイヌアセット
-PROPITEMETC_INC_000327,FWC Golden Hanira Set,FWC ゴールデンハニラセット
-PROPITEMETC_INC_000328,FWC Golden Reine Set,FWCゴールデンレーヌセット
-PROPITEMETC_INC_000329,FWC Golden Rayne Set,FWCゴールデンレインセット
-PROPITEMETC_INC_000330,FWC Golden Roenier Set,FWCゴールデンロニアセット
-PROPITEMETC_INC_000331,FWC Golden Roelayne Set,FWC ゴールデン ローレイン セット
-PROPITEMETC_INC_000332,FWC Golden Reffiro Set,FWCゴールデンレフィロセット
-PROPITEMETC_INC_000333,FWC Golden Rephira Set,FWCゴールデンレフィラセット
-PROPITEMETC_INC_000334,FWC Golden Lippin Set,FWC ゴールデンリピンセット
-PROPITEMETC_INC_000335,FWC Golden Lypine Set,FWCゴールデンライパインセット
+PROPITEMETC_INC_000320,FWC Golden Bileire Set,FWCゴールデン・ビレイアセット
+PROPITEMETC_INC_000321,FWC Golden Bilari Set,FWCゴールデン・ノウセット
+PROPITEMETC_INC_000322,FWC Golden Heraud Set,FWCゴールデン・ヘローセット
+PROPITEMETC_INC_000323,FWC Golden Herainn Set,FWCゴールデン・ヘレイン セット
+PROPITEMETC_INC_000324,FWC Golden Curio Set,FWCゴールデン・キュリオセット
+PROPITEMETC_INC_000325,FWC Golden Curena Set,FWCゴールデン・キュレナセット
+PROPITEMETC_INC_000326,FWC Golden Hainure Set,FWCゴールデン・ハイヌアセット
+PROPITEMETC_INC_000327,FWC Golden Hanira Set,FWCゴールデン・ハニラセット
+PROPITEMETC_INC_000328,FWC Golden Reine Set,FWCゴールデン・レーヌセット
+PROPITEMETC_INC_000329,FWC Golden Rayne Set,FWCゴールデン・レインセット
+PROPITEMETC_INC_000330,FWC Golden Roenier Set,FWCゴールデン・ロニアセット
+PROPITEMETC_INC_000331,FWC Golden Roelayne Set,FWCゴールデン・ローレイン セット
+PROPITEMETC_INC_000332,FWC Golden Reffiro Set,FWCゴールデン・レフィロセット
+PROPITEMETC_INC_000333,FWC Golden Rephira Set,FWCゴールデン・レフィラセット
+PROPITEMETC_INC_000334,FWC Golden Lippin Set,FWCゴールデン・リピンセット
+PROPITEMETC_INC_000335,FWC Golden Lypine Set,FWCゴールデン・ライパインセット
 PROPITEMETC_INC_000336,FWC 2025 Bloody Death Messenger’s Set (Winners),FWC2025ブラッディー・デスメッセンジャーセット（優勝者）
 PROPITEMETC_INC_000337,FWC 2025 Golden Death Messenger’s Set (Finalists),FWC2025ゴールデン・デスメッセンジャーセット（決勝進出者）
 PROPITEMETC_INC_000338,Runthiel Set,ランティエルセット
@@ -283,43 +283,43 @@ PROPITEMETC_INC_000398,Tremiel Set,トレミエルセット
 PROPITEMETC_INC_000399,Tramien Set,トラミエンセット
 PROPITEMETC_INC_000400,Calthien Set,カルシエンセット
 PROPITEMETC_INC_000401,Calthior Set,カルシオルセット
-PROPITEMETC_INC_000402,2026 FWC Golden Virashon Set,2026 FWCゴールデンヴィラションセット
-PROPITEMETC_INC_000403,2026 FWC Golden Verashan Set,2026 FWCゴールデンヴェラシャンセット
-PROPITEMETC_INC_000404,2026 FWC Golden Lenvire Set,2026 FWCゴールデンレンヴィールセット
-PROPITEMETC_INC_000405,2026 FWC Golden Lenvira Set,2026 FWCゴールデンレンヴィラセット
-PROPITEMETC_INC_000406,2026 FWC Golden Kevric Set,2026 FWCゴールデンケブリックセット
-PROPITEMETC_INC_000407,2026 FWC Golden Kevricar Set,2026 FWCゴールデンケブリカーセット
-PROPITEMETC_INC_000408,2026 FWC Golden Chyrelle Set,2026 FWCゴールデンシレルセット
-PROPITEMETC_INC_000409,2026 FWC Golden Chyrella Set,2026 FWCゴールデンシレラセット
-PROPITEMETC_INC_000410,2026 FWC Golden Ustamel Set,2026 FWCゴールデンウスタメルセット
-PROPITEMETC_INC_000411,2026 FWC Golden Ustamen Set,2026 FWCゴールデンウスタメンセット
-PROPITEMETC_INC_000412,2026 FWC Golden Etranor Set,2026 FWCゴールデンエトラノールセット
-PROPITEMETC_INC_000413,2026 FWC Golden Etranar Set,2026 FWCゴールデンエトラナーセット
-PROPITEMETC_INC_000414,2026 FWC Golden Zaythor Set,2026 FWCゴールデンゼイソーセット
-PROPITEMETC_INC_000415,2026 FWC Golden Zaythar Set,2026 FWCゴールデンゼイサーセット
-PROPITEMETC_INC_000416,2026 FWC Golden Runthiel Set,2026 FWCゴールデンランティエルセット
-PROPITEMETC_INC_000417,2026 FWC Golden Runthien Set,2026 FWCゴールデンランティエンセット
-PROPITEMETC_INC_000418,Celestial Phoenix Orange Set,セレスティアルフェニックスオレンジセット
-PROPITEMETC_INC_000419,Celestial Phoenix Purple Set,セレスティアルフェニックスパープルセット
-PROPITEMETC_INC_000420,Celestial Phoenix Green Set,セレスティアルフェニックスグリーンセット
-PROPITEMETC_INC_000421,Celestial Phoenix Cyan Set,セレスティアルフェニックスシアンセット
-PROPITEMETC_INC_000422,Celestial Phoenix Blue Set,セレスティアルフェニックスブルーセット
-PROPITEMETC_INC_000423,Celestial Phoenix Amethyst Set,セレスティアルフェニックスアメジストセット
-PROPITEMETC_INC_000424,Celestial Phoenix Magenta Set,セレスティアルフェニックスマゼンタセット
-PROPITEMETC_INC_000425,Celestial Phoenix Gold Set,セレスティアルフェニックスゴールドセット
-PROPITEMETC_INC_000426,Primordial Runthiel Set,プリモーディアルランティエルセット
-PROPITEMETC_INC_000427,Primordial Runthien Set,プリモーディアルランティエンセット
-PROPITEMETC_INC_000428,Primordial Zaythor Set,プリモーディアルゼイソーセット
-PROPITEMETC_INC_000429,Primordial Zaythar Set,プリモーディアルゼイサーセット
-PROPITEMETC_INC_000430,Primordial Chyrelle Set,プリモーディアルシレルセット
-PROPITEMETC_INC_000431,Primordial Chyrella Set,プリモーディアルシレラセット
-PROPITEMETC_INC_000432,Primordial Lenvire Set,プリモーディアルレンヴィールセット
-PROPITEMETC_INC_000433,Primordial Lenvira Set,プリモーディアルレンヴィラセット
-PROPITEMETC_INC_000434,Primordial Etranor Set,プリモーディアルエトラノールセット
-PROPITEMETC_INC_000435,Primordial Etranar Set,プリモーディアルエトラナーセット
-PROPITEMETC_INC_000436,Primordial Kevric Set,プリモーディアルケブリックセット
-PROPITEMETC_INC_000437,Primordial Kevricar Set,プリモーディアルケブリカーセット
-PROPITEMETC_INC_000438,Primordial Ustamel Set,プリモーディアルウスタメルセット
-PROPITEMETC_INC_000439,Primordial Ustamen Set,プリモーディアルウスタメンセット
-PROPITEMETC_INC_000440,Primordial Virashon Set,プリモーディアルヴィラションセット
-PROPITEMETC_INC_000441,Primordial Verashan Set,プリモーディアルヴェラシャンセット
+PROPITEMETC_INC_000402,2026 FWC Golden Virashon Set,2026 FWCゴールデン・ヴィラションセット
+PROPITEMETC_INC_000403,2026 FWC Golden Verashan Set,2026 FWCゴールデン・ヴェラシャンセット
+PROPITEMETC_INC_000404,2026 FWC Golden Lenvire Set,2026 FWCゴールデン・レンヴィールセット
+PROPITEMETC_INC_000405,2026 FWC Golden Lenvira Set,2026 FWCゴールデン・レンヴィラセット
+PROPITEMETC_INC_000406,2026 FWC Golden Kevric Set,2026 FWCゴールデン・ケブリックセット
+PROPITEMETC_INC_000407,2026 FWC Golden Kevricar Set,2026 FWCゴールデン・ケブリカーセット
+PROPITEMETC_INC_000408,2026 FWC Golden Chyrelle Set,2026 FWCゴールデン・シレルセット
+PROPITEMETC_INC_000409,2026 FWC Golden Chyrella Set,2026 FWCゴールデン・シレラセット
+PROPITEMETC_INC_000410,2026 FWC Golden Ustamel Set,2026 FWCゴールデン・ウスタメルセット
+PROPITEMETC_INC_000411,2026 FWC Golden Ustamen Set,2026 FWCゴールデン・ウスタメンセット
+PROPITEMETC_INC_000412,2026 FWC Golden Etranor Set,2026 FWCゴールデン・エトラノールセット
+PROPITEMETC_INC_000413,2026 FWC Golden Etranar Set,2026 FWCゴールデン・エトラナーセット
+PROPITEMETC_INC_000414,2026 FWC Golden Zaythor Set,2026 FWCゴールデン・ゼイソーセット
+PROPITEMETC_INC_000415,2026 FWC Golden Zaythar Set,2026 FWCゴールデン・ゼイサーセット
+PROPITEMETC_INC_000416,2026 FWC Golden Runthiel Set,2026 FWCゴールデン・ランティエルセット
+PROPITEMETC_INC_000417,2026 FWC Golden Runthien Set,2026 FWCゴールデン・ランティエンセット
+PROPITEMETC_INC_000418,Celestial Phoenix Orange Set,セレスティアルフェニックス・オレンジセット
+PROPITEMETC_INC_000419,Celestial Phoenix Purple Set,セレスティアルフェニックス・パープルセット
+PROPITEMETC_INC_000420,Celestial Phoenix Green Set,セレスティアルフェニックス・グリーンセット
+PROPITEMETC_INC_000421,Celestial Phoenix Cyan Set,セレスティアルフェニックス・シアンセット
+PROPITEMETC_INC_000422,Celestial Phoenix Blue Set,セレスティアルフェニックス・ブルーセット
+PROPITEMETC_INC_000423,Celestial Phoenix Amethyst Set,セレスティアルフェニックス・アメジストセット
+PROPITEMETC_INC_000424,Celestial Phoenix Magenta Set,セレスティアルフェニックス・マゼンタセット
+PROPITEMETC_INC_000425,Celestial Phoenix Gold Set,セレスティアルフェニックス・ゴールドセット
+PROPITEMETC_INC_000426,Primordial Runthiel Set,プリモーディアル・ランティエルセット
+PROPITEMETC_INC_000427,Primordial Runthien Set,プリモーディアル・ランティエンセット
+PROPITEMETC_INC_000428,Primordial Zaythor Set,プリモーディアル・ゼイソーセット
+PROPITEMETC_INC_000429,Primordial Zaythar Set,プリモーディアル・ゼイサーセット
+PROPITEMETC_INC_000430,Primordial Chyrelle Set,プリモーディアル・シレルセット
+PROPITEMETC_INC_000431,Primordial Chyrella Set,プリモーディアル・シレラセット
+PROPITEMETC_INC_000432,Primordial Lenvire Set,プリモーディアル・レンヴィールセット
+PROPITEMETC_INC_000433,Primordial Lenvira Set,プリモーディアル・レンヴィラセット
+PROPITEMETC_INC_000434,Primordial Etranor Set,プリモーディアル・エトラノールセット
+PROPITEMETC_INC_000435,Primordial Etranar Set,プリモーディアル・エトラナーセット
+PROPITEMETC_INC_000436,Primordial Kevric Set,プリモーディアル・ケブリックセット
+PROPITEMETC_INC_000437,Primordial Kevricar Set,プリモーディアル・ケブリカーセット
+PROPITEMETC_INC_000438,Primordial Ustamel Set,プリモーディアル・ウスタメルセット
+PROPITEMETC_INC_000439,Primordial Ustamen Set,プリモーディアル・ウスタメンセット
+PROPITEMETC_INC_000440,Primordial Virashon Set,プリモーディアル・ヴィラションセット
+PROPITEMETC_INC_000441,Primordial Verashan Set,プリモーディアル・ヴェラシャンセット

--- a/Japanese/EquipSets.csv
+++ b/Japanese/EquipSets.csv
@@ -147,7 +147,7 @@ PROPITEMETC_INC_000193,Quinox Set,アズリアエレメンターセット（M）
 PROPITEMETC_INC_000194,Quition Set,アズリアエレメンターセット(F)
 PROPITEMETC_INC_000195,FWC Golden Cryro Set,FWCゴールデン・クライロセット
 PROPITEMETC_INC_000196,FWC Golden Cyrent Set,FWCゴールデン・サイレントセット
-PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWC ゴールデン・フォーベン セット
+PROPITEMETC_INC_000197,FWC Golden Forrben Set,FWCゴールデン・フォーベン セット
 PROPITEMETC_INC_000198,FWC Golden Forrain Set,FWCゴールデン・フォーレインセット
 PROPITEMETC_INC_000199,FWC Golden Naneon Set,FWCゴールデン・ナネオンセット
 PROPITEMETC_INC_000200,FWC Golden Nanex Set,FWCゴールデン・ナネックス セット


### PR DESCRIPTION
### Description
Translates the remaining untranslated entries in `Japanese/EquipSets.csv`.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project