### PR TITLE
[Japanese] Translate remaining untranslated .txt files

### DIFF
--- a/Japanese/BlessingRemove.txt
+++ b/Japanese/BlessingRemove.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ffRemove Blessing#nb#nc
-Remove the Blessing from an item. #b#cffff0000This action cannot be undone.#nc#nb
+﻿#b#cff0000ff祝福の削除#nb#nc
+アイテムから祝福を削除します。#b#cffff0000この操作は元に戻せません。#nc#nb

--- a/Japanese/Colosseum.txt
+++ b/Japanese/Colosseum.txt
@@ -1,3 +1,3 @@
-﻿Welcome, champions. Compete for the #bfastest clear time#nb in the Colosseum to earn great rewards and solidify your name in the competition!
+﻿ようこそ、チャンピオンたちよ。コロシアムで#b最速クリアタイム#nbを競い合い、豪華な報酬を獲得して、その名を大会に刻もう！
 
-Please note that #bonly the highest rank placement will be considered for each player and team#nb. If players have multiple rankings, the others will be ignored. A Guild may have several rank placements, but all participating players must be different in order to qualify for a prize. With this considered, the rank required to receive a prize may differ from the in-game ranking display as it may include multiple entries for the same players.
+なお、#b各プレイヤー・チームともに最も順位の高い記録のみが対象となります#nb。複数の順位を持つ場合、それ以外の記録は無視されます。ギルドが複数の順位に入賞することもありますが、報酬を受け取るには参加プレイヤー全員が異なる必要があります。この仕組みにより、報酬を受け取るために必要な順位は、同じプレイヤーの重複エントリーが含まれる場合があるため、ゲーム内の順位表示と異なることがあります。

--- a/Japanese/CraftPetCandy.txt
+++ b/Japanese/CraftPetCandy.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ff Pet Candy Crafting #nb#nc
-Craft #bPet Candy#nb by combining berries with Penya. The tier of the Pet Candy depends on the berry used.
+﻿#b#cff0000ff ペットキャンディー作成 #nb#nc
+ベリーとペニャを組み合わせて#bペットキャンディー#nbを作成します。ペットキャンディーのティアは使用するベリーによって決まります。

--- a/Japanese/CraftPetCandyExample.txt
+++ b/Japanese/CraftPetCandyExample.txt
@@ -1,7 +1,7 @@
-﻿#b#cff0000ff Recipes #nb#nc
- #b25x Cloudberry#nb = 1x Pet Candy (F)#nc
- #b50x Cloudberry + 1x Pet Candy (F)#nb = 1x Pet Candy (E)#nc
- #b50x Lightberry + 1x Pet Candy (E)#nb = 1x Pet Candy (D)#nc
- #b50x Lightberry + 1x Pet Candy (D)#nb = 1x Pet Candy (C)#nc
- #b50x Lightberry + 1x Pet Candy (C)#nb = 1x Pet Candy (B)#nc
- #b100x Exoberry + 1x Pet Candy (B)#nb = 1x Pet Candy (A)#nc
+﻿#b#cff0000ff レシピ #nb#nc
+ #bクラウドベリー25個#nb = ペットキャンディー(F)1個#nc
+ #bクラウドベリー50個 + ペットキャンディー(F)1個#nb = ペットキャンディー(E)1個#nc
+ #bライトベリー50個 + ペットキャンディー(E)1個#nb = ペットキャンディー(D)1個#nc
+ #bライトベリー50個 + ペットキャンディー(D)1個#nb = ペットキャンディー(C)1個#nc
+ #bライトベリー50個 + ペットキャンディー(C)1個#nb = ペットキャンディー(B)1個#nc
+ #bエクソベリー100個 + ペットキャンディー(B)1個#nb = ペットキャンディー(A)1個#nc

--- a/Japanese/CreateGem.txt
+++ b/Japanese/CreateGem.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ff Create Jewel #nb#nc
-Create jewels by dismantling weapons with a required level of 60 or higher. The number of jewels created depends on the weapon's upgrade level (+1 to +10) and required level. The success rate also depends on the weapon's upgrade level. #b#cffff0000If the conversion fails, the weapon is destroyed and no jewels are created.#nc#nb
+﻿#b#cff0000ff 宝石を作る #nb#nc
+必要レベル60以上の武器を分解することで宝石を作成できます。作成される宝石の数は、武器の強化レベル（+1〜+10）と必要レベルによって決まります。成功率も武器の強化レベルによって変わります。#b#cffff0000変換に失敗すると武器は破壊され、宝石は作成されません。#nc#nb

--- a/Japanese/CreateShiningDice.txt
+++ b/Japanese/CreateShiningDice.txt
@@ -1,4 +1,4 @@
-﻿#b#cff0000ff Shining Power Dice Creation #nb#nc
-#bShining Power Dice 4#nb is created by merging 5x Power Dice 4 and 5x Power Dice 8.
-#bShining Power Dice 6#nb is created by merging 5x Power Dice 6 and 5x Power Dice 8.
-#bShining Power Dice 12#nb is created by using Power Dice 12 or Power Dice 10 in the process.
+﻿#b#cff0000ff 輝くパワーダイス作成 #nb#nc
+#b輝くパワーダイス4#nbは、パワーダイス4を5個とパワーダイス8を5個合成することで作成されます。
+#b輝くパワーダイス6#nbは、パワーダイス6を5個とパワーダイス8を5個合成することで作成されます。
+#b輝くパワーダイス12#nbは、パワーダイス12またはパワーダイス10を使用することで作成されます。

--- a/Japanese/Dismantle.txt
+++ b/Japanese/Dismantle.txt
@@ -1,3 +1,3 @@
-﻿#b#cff0000ff Dismantle Item #nb#nc
-Dismantling an item will destroy the original item and convert it into one or more other items.
-#b#cffff0000This action cannot be undone.#nb#nc
+﻿#b#cff0000ff アイテムの解体 #nb#nc
+アイテムを解体すると、元のアイテムは破壊され、1つ以上の別のアイテムに変換されます。
+#b#cffff0000この操作は元に戻せません。#nb#nc

--- a/Japanese/Donation.txt
+++ b/Japanese/Donation.txt
@@ -1,6 +1,6 @@
-﻿#bDonate Penya#nb to unlock #b3 hours of server-wide buffs#nb for #ball players#nb.
-Players who donate will also receive a #bslightly stronger buff#nb!
+﻿#bペニャを寄付する#nbと、#b全プレイヤー#nbを対象に#bサーバー全体で3時間のバフ#nbが解放されます。
+寄付したプレイヤーは、#bさらに少し強力なバフ#nbも受け取れます！
 
-#bNote:#nb Donated #bPenya#nb will #bcarry over#nb if the #bfirst donation goal#nb is not reached.
+#b注意：#nb#b最初の寄付目標#nbに到達しなかった場合、寄付した#bペニャ#nbは#b繰り越されます#nb。
 
-Additionally, the #bTop Donor of the Week#nb becomes the #bServer Lord#nb and gains access to #bexclusive time-limited skills and rewards#nb. Visit the #bLord Manager in Flarine#nb for more information.
+さらに、#b週間トップ寄付者#nbは#bサーバーロード#nbとなり、#b期間限定の特別なスキルと報酬#nbを利用できるようになります。詳しくは#bフラリスのロードマネージャー#nbまでお尋ねください。

--- a/Japanese/ElementChange.txt
+++ b/Japanese/ElementChange.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ff Scroll of Element Change#nb#nc
-Place a weapon or suit with an element upgrade in the box above, then select an element icon below to change its element.
+﻿#b#cff0000ff 属性変更の巻物#nb#nc
+属性精錬済みの武器またはスーツを上のボックスに入れ、下の属性アイコンを選択すると属性を変更できます。

--- a/Japanese/ElementUpgrade.txt
+++ b/Japanese/ElementUpgrade.txt
@@ -1,5 +1,5 @@
-﻿#bElement Upgrading#nb
+﻿#b属性精錬#nb
 
-Infusing an item with an element increases its effectiveness against enemies of weaker elements, but decreases its effectiveness against enemies of stronger elements.
-#cffff0000From +3 onward, a failed upgrade will destroy the item unless a Scroll of SProtect is used.
-Low Scroll of SProtect prevents destruction but reduces the upgrade level on failure.#nc
+アイテムに属性を付与すると、自身より弱い属性を持つ敵に対する効果が上がりますが、自身より強い属性を持つ敵に対する効果は下がります。
+#cffff0000+3以降は、精錬編(SProtect)を使用しない場合、失敗時にアイテムが破壊されます。
+下級精錬編(SProtect)を使用すると破壊は防げますが、失敗時に精錬レベルが下がります。#nc

--- a/Japanese/FWCPrediction2025.txt
+++ b/Japanese/FWCPrediction2025.txt
@@ -1,36 +1,36 @@
-﻿1. FWC Coin Collection Period (Sep 4 – Oct 17)
- * Description: This is the period to collect the FWC Coins required for participation.
- * How to Collect: Complete missions, participate in event content, and more.
- * Note: You cannot place bets without FWC Coins.
+﻿1. FWCコイン収集期間（9月4日〜10月17日）
+ * 説明：参加に必要なFWCコインを収集する期間です。
+ * 収集方法：ミッションのクリアやイベントコンテンツへの参加などで入手できます。
+ * 注意：FWCコインがないとベットできません。
 
-2. Prediction Period (Oct 1 – Oct 17)
- * Description: You can place bets on one of the ten Guilds during this period.
- * System: Fixed payout multipliers (not real-time odds).
- * Important Notes:
-  - Once placed, bets cannot be canceled or modified.
-  - You can review your bet history in the Prediction Log.
-  - Minimum bet amount: 50 coins.
+2. 予想期間（10月1日〜10月17日）
+ * 説明：この期間中、10ギルドの中から1つを選んでベットできます。
+ * システム：配当倍率は固定制です（リアルタイムのオッズではありません）。
+ * 重要な注意事項：
+  - 一度確定したベットは、キャンセルや変更ができません。
+  - ベット履歴は予想ログで確認できます。
+  - 最小ベット額：50コイン
 
-3. Settlement Period (Oct 18 – Oct 23, 5days)
- * Description: After the tournament ends, rewards are calculated based on final Guild rankings.
- * Note: Actual rewards are not yet distributed during this period.
- * Payout Rates:
-  - 1st Place: x3
-  - 2nd Place: x2
-  - 3rd–4th Place: x1.5
-  - 5th–10th Place: x1.1
+3. 精算期間（10月18日〜10月23日、5日間）
+ * 説明：大会終了後、最終ギルド順位に基づいて報酬が計算されます。
+ * 注意：この期間中、実際の報酬はまだ配布されません。
+ * 配当倍率：
+  - 1位：×3
+  - 2位：×2
+  - 3〜4位：×1.5
+  - 5〜10位：×1.1
 
-4. Payout Distribution Period (Oct 23)
- * Description: This is the period when all users receive their dividend payouts after the final settlement is completed.
- * Distribution Method: Each user receives Champion Coins based on their Prediction history, either via in-game mail or directly distributed.
- * Rewards: Users earn Champion Coins based on (amount bet) × (final ranking of the Guild they bet on).
- * Dividend rankings will be revealed, and special titles will be granted accordingly.
- * Note:
-  - All rewards are distributed at once (not in real time).
-  - Champion Coins will be deleted once the item exchange period ends.
-  - If delivered via mail, the expiration will be set to match the end of the item exchange period.
+4. 配当支給期間（10月23日）
+ * 説明：最終精算完了後、全ユーザーに配当が支給される期間です。
+ * 配布方法：各ユーザーは、自身の予想履歴に応じてチャンピオンコインを受け取ります。ゲーム内メールまたは直接配布のいずれかの方法で支給されます。
+ * 報酬：獲得チャンピオンコインは、（ベット額）×（ベットしたギルドの最終順位）で算出されます。
+ * 配当ランキングが公開され、それに応じて特別称号が付与されます。
+ * 注意：
+  - 報酬は一括で配布されます（リアルタイムではありません）。
+  - チャンピオンコインは、アイテム交換期間の終了とともに削除されます。
+  - メールで配布される場合、有効期限はアイテム交換期間の終了に合わせて設定されます。
 
-5. Item Exchange Period (Oct 23 – Nov 6, 14days)
- * Description: Users can exchange their earned Champion Coins for items in the event-exclusive shop.
- * Period: Limited-time exchange available for 2 weeks after the tournament ends.
- * Note: Champion Coins will expire if not used within the exchange period.
+5. アイテム交換期間（10月23日〜11月6日、14日間）
+ * 説明：獲得したチャンピオンコインは、イベント限定ショップでアイテムと交換できます。
+ * 期間：大会終了後2週間の期間限定で交換可能です。
+ * 注意：交換期間内に使用しなかったチャンピオンコインは失効します。

--- a/Japanese/GeneralUpgrade.txt
+++ b/Japanese/GeneralUpgrade.txt
@@ -1,6 +1,6 @@
-﻿#bItem Upgrading#nb
+﻿#bアイテムの精錬#nb
 
-Upgrading an item increases its base stats and overall power or defenses.
-#cffff0000From +3 onward (+0 onward for ultimate items), a failed upgrade will destroy the item unless a protection scroll is used.
-Scroll of SProtect is used for normal items, Scroll of AProtect for normal accessories, and Scroll of XProtect for ultimate items.
-Low Scroll of SProtect can only be used when upgrading normal equipment, and reduces the upgrade level on failure.#nc
+アイテムを精錬すると、基本ステータスや全体的な攻撃力・防御力が上がります。
+#cffff0000+3以降（アルティマアイテムは+0以降）は、保護巻物を使用しない限り、精錬に失敗するとアイテムが破壊されます。
+通常アイテムには精錬編(SProtect)、通常アクセサリーにはアクセサリー編(AProtect)、アルティマアイテムにはアルティマ編(XProtect)を使用します。
+下級精錬編(SProtect)は通常装備の精錬時のみ使用でき、失敗時に精錬レベルが下がります。#nc

--- a/Japanese/GuildCombat165.txt
+++ b/Japanese/GuildCombat165.txt
@@ -1,18 +1,18 @@
-﻿#b#cff0000ff* Level 165 Guild Siege#nb#nc
-Welcome to the Level 165 Guild Siege! This competition is available to players who did not complete their third class change yet.
+﻿#b#cff0000ff* Lv165ギルドコンバット#nb#nc
+Lv165ギルドコンバットへようこそ！この大会は、3次転職を完了していないプレイヤーが参加できます。
 
-Please ask the [Guild Siege Manager] Donaris for more information about the fight.
+対戦の詳細については、[ギルコンマネージャー]ドナリスにお尋ねください。
 
-Pets cannot be summoned during this Guild Siege.
+このギルドコンバット中はペットを召喚できません。
 
-#b#cff0000ff* Reward Blue Chips#nb#nc
-- Winning Guild: 20 x number of participating guilds
-- Second Guild: 15 x number of participating guilds
-- Third Guild: 10 x number of participating guilds
-- Fourth Guild: 5 x number of participating guilds
-- Fifth Guild: 3 x number of participating guilds
-- Sixth Guild: 2 x number of participating guilds
-- Seventh Guild: 2 x number of participating guilds
-- Eighth Guild: 2 x number of participating guilds
-- Ninth Guild: 2 x number of participating guilds
-- Tenth Guild: 2 x number of participating guilds
+#b#cff0000ff* ブルーチップ報酬#nb#nc
+- 優勝ギルド：20×参加ギルド数
+- 第2ギルド：15×参加ギルド数
+- 第3ギルド：10×参加ギルド数
+- 第4ギルド：5×参加ギルド数
+- 第5ギルド：3×参加ギルド数
+- 第6ギルド：2×参加ギルド数
+- 第7ギルド：2×参加ギルド数
+- 第8ギルド：2×参加ギルド数
+- 第9ギルド：2×参加ギルド数
+- 第10ギルド：2×参加ギルド数

--- a/Japanese/GuildCombat60.txt
+++ b/Japanese/GuildCombat60.txt
@@ -1,16 +1,16 @@
-﻿#b#cff0000ff Level 60 Guild Siege #nb#nc
-Welcome to the Level 60 Guild Siege!
-This Guild Siege is available to players who have not completed their second class change.
+﻿#b#cff0000ff Lv60ギルドコンバット #nb#nc
+Lv60ギルドコンバットへようこそ！
+このギルドコンバットは、2次転職を完了していないプレイヤーが参加できます。
 
-Please speak with [Guild Siege Manager] Donaris for more information.
+詳しくは[ギルコンマネージャー]ドナリスにお尋ねください。
 
-#bPets cannot be summoned during this Guild Siege.#nb
+#bこのギルドコンバット中はペットを召喚できません。#nb
 
-#b#cff0000ff Blue Chip Rewards #nb#nc
-※ Rewards are granted based on final placement and the number of participating guilds.
-  - 1st Place Guild: 16 x number of participating guilds
-  - 2nd Place Guild: 11 x number of participating guilds
-  - 3rd Place Guild: 6 x number of participating guilds
-  - 4th Place Guild: 4 x number of participating guilds
-  - 5th Place Guild: 2 x number of participating guilds
-  - 6th–10th Place Guilds: 1 x number of participating guilds
+#b#cff0000ff ブルーチップ報酬 #nb#nc
+※ 報酬は最終順位と参加ギルド数に応じて付与されます。
+  - 1位ギルド：16×参加ギルド数
+  - 2位ギルド：11×参加ギルド数
+  - 3位ギルド：6×参加ギルド数
+  - 4位ギルド：4×参加ギルド数
+  - 5位ギルド：2×参加ギルド数
+  - 6〜10位ギルド：1×参加ギルド数

--- a/Japanese/GuildCombat80.txt
+++ b/Japanese/GuildCombat80.txt
@@ -1,16 +1,16 @@
-﻿#b#cff0000ff Level 80 Guild Siege #nb#nc
-Welcome to the Level 80 Guild Siege!
-This Guild Siege is available to players up to level 80.
+﻿#b#cff0000ff Lv80ギルドコンバット #nb#nc
+Lv80ギルドコンバットへようこそ！
+このギルドコンバットは、レベル80以下のプレイヤーが参加できます。
 
-Please speak with [Guild Siege Manager] Donaris for more information.
+詳しくは[ギルコンマネージャー]ドナリスにお尋ねください。
 
-#bPets cannot be summoned during this Guild Siege.#nb
+#bこのギルドコンバット中はペットを召喚できません。#nb
 
-#b#cff0000ff Blue Chip Rewards #nb#nc
-※ Rewards are granted based on final placement and the number of participating guilds.
-  - 1st Place Guild: 17 x number of participating guilds
-  - 2nd Place Guild: 12 x number of participating guilds
-  - 3rd Place Guild: 7 x number of participating guilds
-  - 4th Place Guild: 4 x number of participating guilds
-  - 5th Place Guild: 2 x number of participating guilds
-  - 6th–10th Place Guilds: 1 x number of participating guilds
+#b#cff0000ff ブルーチップ報酬 #nb#nc
+※ 報酬は最終順位と参加ギルド数に応じて付与されます。
+  - 1位ギルド：17×参加ギルド数
+  - 2位ギルド：12×参加ギルド数
+  - 3位ギルド：7×参加ギルド数
+  - 4位ギルド：4×参加ギルド数
+  - 5位ギルド：2×参加ギルド数
+  - 6〜10位ギルド：1×参加ギルド数

--- a/Japanese/GuildCombat_ApplyingFee.txt
+++ b/Japanese/GuildCombat_ApplyingFee.txt
@@ -1,4 +1,4 @@
-﻿#b#cff0000ff Application Fee Information #nb#nc
-※ If you cancel your application, 20% of the application fee is deducted.
-※ If your application does not place in the top 10 bidding guilds, 2% of the application fee is deducted.
-※ The 10 guilds that successfully enter Guild Siege do not receive a refund of the application fee.
+﻿#b#cff0000ff 入札金情報 #nb#nc
+※ 申請をキャンセルした場合、入札金の20%が差し引かれます。
+※ 入札上位10ギルドに入らなかった場合、入札金の2%が差し引かれます。
+※ ギルドコンバットへの参加が確定した10ギルドには、入札金は返金されません。

--- a/Japanese/GuildCombat_Participation.txt
+++ b/Japanese/GuildCombat_Participation.txt
@@ -1,16 +1,16 @@
-﻿#b#cff0000ff Participation Information #nb#nc
-※ Application Time: Any time outside of the Guild Siege event period.
-※ Combat Location: Channel 1
-※ Conditions
-  - Guild level must be 6 or higher.
-  - Guild members must be level 30 or higher.
-  - The Guild Master or any Kingpin must participate.
-  - Up to 10 guilds can participate. If more than 10 guilds apply, the guilds that paid the highest application fee are selected (fees are compared when the application period ends).
-※ Schedule
-  - Lineup Setup (10 minutes): The Guild Master or any Kingpin may set and edit the lineup. Up to 15 guild members may participate. One participant must be designated as the defender.
-  - Entry Phase (7 minutes): Participating players may enter the Guild Siege arena and wait.
-  - Preparation Phase (3 minutes): The first 6 players from each participating guild are teleported into the Guild Siege combat area.
-  - Battle Phase (40 minutes): Combat begins and continues until the Guild Siege ends.
-※ Notes
-  - When more than 5 guilds participate, a large battlefield is used, and the Battle Phase lasts 55 minutes.
-  - #b#cffff0000 Guild Siege will only begin if 2 or more guilds are accepted.#nb#nc
+﻿#b#cff0000ff 参加情報 #nb#nc
+※ 申請時間：ギルドコンバット開催期間以外はいつでも可能です。
+※ 対戦場所：チャンネル1
+※ 参加条件
+  - ギルドレベルが6以上であること。
+  - ギルドメンバーがレベル30以上であること。
+  - ギルドマスターまたはキングピンが参加していること。
+  - 最大10ギルドまで参加可能です。申請ギルドが10を超えた場合、入札金の高いギルドから選出されます（入札金は申請期間終了時に比較されます）。
+※ スケジュール
+  - 参加メンバー構成（10分）：ギルドマスターまたはキングピンが参加メンバーの設定・編集を行えます。最大15名のギルドメンバーが参加でき、そのうち1名をディフェンダーに指定する必要があります。
+  - エントリーフェーズ（7分）：参加プレイヤーはギルドコンバットエリアに入場し、待機できます。
+  - 準備フェーズ（3分）：各参加ギルドの先頭6名が、ギルドコンバットの戦闘エリアへ転送されます。
+  - 戦闘フェーズ（40分）：戦闘が開始され、ギルドコンバットが終了するまで続きます。
+※ 注意事項
+  - 参加ギルドが5を超える場合、大規模な戦場が使用され、戦闘フェーズは55分間になります。
+  - #b#cffff0000 ギルドコンバットは、2ギルド以上が参加確定した場合のみ開催されます。#nb#nc

--- a/Japanese/GuildCombat_Reward.txt
+++ b/Japanese/GuildCombat_Reward.txt
@@ -1,25 +1,25 @@
-﻿#b#cff0000ff Reward Information #nb#nc
+﻿#b#cff0000ff 報酬情報 #nb#nc
 
-※ Red Chip Rewards
-  - All guilds that meet the minimum point requirement receive 1,000 Red Chips per participating guild member.
+※ レッドチップ報酬
+  - 最低ポイント条件を満たした全てのギルドは、参加ギルドメンバー1人につきレッドチップ1,000個を受け取れます。
 
-※ Green Chip Rewards
-  - 1st Place Guild: 150 per participating guild member
-  - 2nd Place Guild: 100 per participating guild member
-  - 3rd Place Guild: 50 per participating guild member
-  - 4th Place Guild: 25 per participating guild member
-  - 5th Place Guild: 13 per participating guild member
-  - 6th–10th Place Guilds: 6 per participating guild member
+※ グリーンチップ報酬
+  - 1位ギルド：参加ギルドメンバー1人につき150個
+  - 2位ギルド：参加ギルドメンバー1人につき100個
+  - 3位ギルド：参加ギルドメンバー1人につき50個
+  - 4位ギルド：参加ギルドメンバー1人につき25個
+  - 5位ギルド：参加ギルドメンバー1人につき13個
+  - 6〜10位ギルド：参加ギルドメンバー1人につき6個
 
-※ Penya Rewards
-  - Winning Guild: 35% of the total application money
-  - Best Player: 15% of the total application money
+※ ペニャ報酬
+  - 優勝ギルド：入札金合計の35%
+  - MVP：入札金合計の15%
 
-※ Special Rewards
-  - 1 consecutive victory: Dragon Cloak of the Initiate (All Stats +5)
-  - 2 consecutive victories: Dragon Cloak of the Adept (All Stats +6, Max HP +100)
-  - 3 consecutive victories: Dragon Cloak of the Master (All Stats +7, Max HP +100)
-  - 4 consecutive victories: Dragon Cloak of the Hero (All Stats +8, Max HP +100)
+※ 特別報酬
+  - 1回連続優勝：挑戦のドラゴンマント（全ステータス+5）
+  - 2回連続優勝：勇気のドラゴンマント（全ステータス+6、最大HP+100）
+  - 3回連続優勝：野望のドラゴンマント（全ステータス+7、最大HP+100）
+  - 4回連続優勝：至尊のドラゴンマント（全ステータス+8、最大HP+100）
 
-#b#cffff0000※ A button will appear that allows Dragon Cloaks to be created freely in the Guild Warehouse.#nb#nc
-※ Dragon Cloaks can only be equipped until the next Guild Siege begins.
+#b#cffff0000※ ギルド倉庫でドラゴンマントを自由に作成できるボタンが表示されます。#nb#nc
+※ ドラゴンマントは、次回のギルドコンバットが始まるまでの間のみ装備できます。

--- a/Japanese/GuildCombat_Rules.txt
+++ b/Japanese/GuildCombat_Rules.txt
@@ -1,9 +1,9 @@
-﻿#b#cff0000ff Basic Rules #nb#nc
-※ All buffs are removed when entering the Guild Siege arena.
-※ Item trading is disabled in the Guild Siege arena.
-※ Combat begins after the Entry and Preparation phases.
-※ The first 6 players in the lineup enter the Guild Siege combat area.
-※ When a player is defeated, the next player in the lineup enters.
-※ Defeated players are moved to the end of the lineup.
-※ Each player has 9 revival opportunities.
-※ Defenders grant 1 bonus point to the enemy when defeated.
+﻿#b#cff0000ff 基本ルール #nb#nc
+※ ギルドコンバットエリアに入場すると、全てのバフが解除されます。
+※ ギルドコンバットエリア内では、アイテム取引ができません。
+※ エントリーフェーズと準備フェーズの後、戦闘が開始されます。
+※ 参加メンバーの先頭6名が、ギルドコンバットの戦闘エリアに入場します。
+※ プレイヤーが倒されると、次の参加メンバーが入場します。
+※ 倒されたプレイヤーは、参加メンバーの最後尾に移動します。
+※ 各プレイヤーの復活回数は9回です。
+※ ディフェンダーが倒されると、敵に1ボーナスポイントが与えられます。

--- a/Japanese/GuildCombat_Winning.txt
+++ b/Japanese/GuildCombat_Winning.txt
@@ -1,14 +1,14 @@
-﻿#b#cff0000ff Winning Conditions #nb#nc
+﻿#b#cff0000ff 勝利条件 #nb#nc
 
-※ Priority
-  1. Highest final points
-  2. Highest total remaining revival opportunities of surviving players
-  3. Lowest average level of surviving players
+※ 優先順位
+  1. 最終ポイントが最も高い
+  2. 生存プレイヤーの残り復活回数の合計が最も多い
+  3. 生存プレイヤーの平均レベルが最も低い
 
-#b#cff0000ff Point Gain #nb#nc
-※ Defeating an enemy player grants 2 points.
+#b#cff0000ff ポイント獲得 #nb#nc
+※ 敵プレイヤーを倒すと2ポイント獲得します。
 
-#b#cff0000ff Bonus Point Gain (Bonuses can stack) #nb#nc
-※ Defeating the Defender grants 1 bonus point.
-※ Defeating an enemy player with 0 remaining revival opportunities grants 1 bonus point.
-※ Each remaining revival opportunity of surviving players grants 1 bonus point.
+#b#cff0000ff ボーナスポイント獲得（ボーナスは重複可能） #nb#nc
+※ ディフェンダーを倒すと1ボーナスポイント獲得します。
+※ 残り復活回数が0の敵プレイヤーを倒すと1ボーナスポイント獲得します。
+※ 生存プレイヤーの残り復活回数1回につき、1ボーナスポイントを獲得します。

--- a/Japanese/KalgasAssault.txt
+++ b/Japanese/KalgasAssault.txt
@@ -1,26 +1,26 @@
-﻿#cff0000ff Kalgas Assault #nc
-Two teams face off in an intense battle to seize control of the mighty boss, Kalgas!
-Destroy the artifacts guarding Kalgas to unleash devastating damage and turn the tide of battle.
-Various rewards await those who rise to the challenge!
+﻿#cff0000ff カルガスアサルト #nc
+2チームに分かれ、強大なボス「カルガス」の支配権を巡って激しい戦いを繰り広げます！
+カルガスを守るアーティファクトを破壊すると、強力なダメージを解き放ち、戦況を一変させることができます。
+挑戦者には様々な報酬が待っています！
 
-#cff0000ff Rules #nc
-1. Capturing an artifact grants a buff that increases the damage dealt to Kalgas. The more artifacts your team controls, the greater the damage bonus.
-2. Players with insufficient contribution will not receive rewards.
-3. The team that deals more damage to Kalgas and achieves the higher rate by the end of the assault is declared the winner.
-  - If a team's rate exceeds 80% and is maintained for 1 minute, the assault ends immediately and that team claims victory.
-4. Winning Priority:
-  - Rate
-  - Number of captured artifacts
-  - Player kills between teams
-5. If Kalgas Assault begins without an opposing team, and no damage is dealt to Kalgas, the event will end in a draw.
+#cff0000ff ルール #nc
+1. アーティファクトを占領すると、カルガスへのダメージが増加するバフを獲得します。占領するアーティファクトが多いほど、ダメージボーナスは大きくなります。
+2. 貢献度が不足しているプレイヤーは報酬を受け取れません。
+3. アサルト終了時点でカルガスへのダメージが多く、レートが高いチームが勝者となります。
+  - チームのレートが80%を超え、1分間維持された場合、アサルトは即座に終了し、そのチームの勝利となります。
+4. 勝利優先順位：
+  - レート
+  - 占領したアーティファクトの数
+  - チーム間のプレイヤーキル数
+5. 対戦相手のいない状態でカルガスアサルトが開始され、カルガスにダメージが与えられなかった場合、そのイベントは引き分けで終了します。
 
-#cff0000ff Rewards #nc
-※ Participation Reward: 5x Kalgas Chips
-※ Winning Team Reward: 10x Kalgas Chips
-※ Category Rankings
-  - 1st Place: 30x Kalgas Chips
-  - 2nd Place: 20x Kalgas Chips
-  - 3rd Place: 15x Kalgas Chips
+#cff0000ff 報酬 #nc
+※ 参加報酬：カルガスチップ5個
+※ 勝利チーム報酬：カルガスチップ10個
+※ 順位別報酬
+  - 1位：カルガスチップ30個
+  - 2位：カルガスチップ20個
+  - 3位：カルガスチップ15個
 
-※ In the event of a draw, only participation rewards and category ranking rewards are granted. Winning Team rewards are not granted.
-※ The final number of Kalgas Chips awarded is based on the player's contribution amount.
+※ 引き分けの場合、参加報酬と順位別報酬のみが付与されます。勝利チーム報酬は付与されません。
+※ 最終的に付与されるカルガスチップの数は、プレイヤーの貢献度に応じて決まります。

--- a/Japanese/KalgasAssaultReg.txt
+++ b/Japanese/KalgasAssaultReg.txt
@@ -1,12 +1,12 @@
-﻿#cff0000ffRegistration#nc
-Kalgas Assault Match Time: Every %s %s ~ %s (Max. %d min)
-Minimum Level: %d
-Registration Time: Every %s %s ~ %s %s
-Entry Time: %s ~ %s
-Current Number of Registered Players: %d
+﻿#cff0000ff登録#nc
+カルガスアサルト開催時間：毎週%s %s～%s（最大%d分）
+最小レベル: %d
+登録時間：毎週%s %s～%s %s
+入場時間：%s～%s
+現在の登録プレイヤー数：%d
 
-※ Only players who have registered for Kalgas Assault may participate.
-※ Entry is not possible after the entry time has ended.
-※ A maximum of 200 players can participate per instance (100 vs 100).
-※ Ranking rewards are granted only if 20 or more players participate. If fewer than 20 players participate, only the winner reward is granted.
-※ Teams are selected randomly.
+※ カルガスアサルトに登録したプレイヤーのみ参加できます。
+※ 入場時間終了後は入場できません。
+※ 1インスタンスあたり最大200人が参加できます（100対100）。
+※ 順位報酬は20人以上参加した場合のみ付与されます。20人未満の場合、勝者報酬のみ付与されます。
+※ チームはランダムに選出されます。

--- a/Japanese/LevelDownRemove.txt
+++ b/Japanese/LevelDownRemove.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ffRemove Level Reduction#nb#nc
-Remove the level reduction from an item. #b#cffff0000This action cannot be undone.#nc#nb
+﻿#b#cff0000ff装備可能レベル低下キャンセル#nb#nc
+アイテムの装備可能レベル低下をキャンセルします。#b#cffff0000この操作は元に戻せません。#nc#nb

--- a/Japanese/Lottery.txt
+++ b/Japanese/Lottery.txt
@@ -1,7 +1,7 @@
-﻿#cffff0000Welcome to the Flyff Universe Lottery Wheel!#nc
+﻿#cffff0000Flyff Universeのラッキールーレットへようこそ！#nc
 
-Get enough event items to try your luck spinning the wheel! You can win incredible rewards!
+イベントアイテムを十分に集めて、運試しにルーレットを回してみよう！素晴らしい報酬が当たるかも！
 
-Items have different probabilities to win them, so don’t be disappointed if you don’t get the best prize on your first try!
+アイテムごとに当選確率は異なります。1回目で最高の景品が出なくてもがっかりしないでね！
 
-#cffff0000Good luck to you!#nc
+#cffff0000幸運を祈ります！#nc

--- a/Japanese/LotteryTrickOrTreat.txt
+++ b/Japanese/LotteryTrickOrTreat.txt
@@ -1,9 +1,9 @@
-﻿#cffff0000Welcome to the Flyff Universe Lottery Wheel!#nc
+﻿#cffff0000Flyff Universeのラッキールーレットへようこそ！#nc
 
-Get enough event items to try your luck spinning the wheel! You can win incredible rewards!
+イベントアイテムを十分に集めて、運試しにルーレットを回してみよう！素晴らしい報酬が当たるかも！
 
-Items have different probabilities to win them, so don’t be disappointed if you don’t get the best prize on your first try!
+アイテムごとに当選確率は異なります。1回目で最高の景品が出なくてもがっかりしないでね！
 
-This roulette is available up to 20 times a day and will be initialized at 0 o'clock
+このルーレットは1日20回まで挑戦でき、0時にリセットされます。
 
-#cffff0000Good luck to you!#nc
+#cffff0000幸運を祈ります！#nc

--- a/Japanese/Notice.txt
+++ b/Japanese/Notice.txt
@@ -1,11 +1,11 @@
-﻿#cffff0000 Welcome to the fabulous world of Flyff! #nc
+﻿#cffff0000 素晴らしきFlyffの世界へようこそ！ #nc
 
-The continent of Madrigal has known many conflicts...
-But now, it seeks harmony, mutual support, and peace.
+マドリガル大陸は、数多くの争いを経験してきました……
+しかし今、この大陸は調和と相互扶助、そして平和を求めています。
 
-As Rhisis would wish,
-respect and help your fellow citizens of Madrigal.
+リシスが望むように、
+マドリガルの同胞たちを敬い、助け合いましょう。
 
-Enjoy the adventure!
+冒険を楽しんでください！
 
-#cffff0000 Discover the project at $WEBSITE$! #nc
+#cffff0000 $WEBSITE$ でプロジェクトの詳細をご覧ください！ #nc

--- a/Japanese/PetRecycle.txt
+++ b/Japanese/PetRecycle.txt
@@ -1,4 +1,4 @@
-﻿#b#cff0000ff Pet Sacrificing #nb#nc
-You can #bchange the level#nb of your #bcurrently summoned pet's tier#nb by sacrificing another pet of the #bsame tier or higher#nb.
-#cffff0000The pet you select below will be permanently destroyed.#nc
-Sacrificing a higher-tier pet increases the chance of obtaining a higher level.
+﻿#b#cff0000ff ペットサクリファイス #nb#nc
+#b現在召喚しているペットのティア#nbと#b同じか、それ以上のティア#nbの別のペットを犠牲にすることで、そのペットの#bレベルを変更#nbできます。
+#cffff0000下で選択したペットは完全に消滅します。#nc
+より高いティアのペットを犠牲にすると、より高いレベルを獲得できる確率が上がります。

--- a/Japanese/PetReroll.txt
+++ b/Japanese/PetReroll.txt
@@ -1,5 +1,5 @@
-﻿#b#cff0000ff Pet Rerolling #nb#nc
-You can #bchange the level#nb of a selected tier, resulting in a new random level that may be #bhigher or lower#nb than the current level.
-#cffff0000 The number of scrolls shown when selecting a tier will be consumed. #nc
-Once rerolling is confirmed, the selected tier is permanently set as the #bonly tier eligible for rerolling with reroll scrolls#nb.
-Rerolling the last tier is still possible through pet sacrificing.
+﻿#b#cff0000ff ペットリロール #nb#nc
+選択したティアの#bレベルを変更#nbでき、現在のレベルより#b高くなることも低くなることも#nbある、新しいランダムなレベルになります。
+#cffff0000 ティア選択時に表示される数の巻物が消費されます。 #nc
+リロールを確定すると、選択したティアが#bリロール巻物でリロール可能な唯一のティア#nbとして永続的に設定されます。
+最後のティアのリロールは、ペットサクリファイスを通じて引き続き可能です。

--- a/Japanese/Piercing.txt
+++ b/Japanese/Piercing.txt
@@ -1,4 +1,4 @@
-﻿#bItem Piercing#nb
+﻿#bアイテムのソケット作成#nb
 
-Piercing an item unlocks slots for piercing cards, which can greatly enhance the item's capabilities and power.
-#cffff0000Using a Scroll of GProtect prevents the item from being destroyed on failure.#nc
+アイテムにソケットを作成すると、ソケットカード用のスロットが解放され、アイテムの性能と威力を大幅に強化できます。
+#cffff0000ソケット作成編(GProtect)を使用すると、失敗時にアイテムが破壊されるのを防げます。#nc

--- a/Japanese/PiercingRemove.txt
+++ b/Japanese/PiercingRemove.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ffRemove Piercing#nb#nc
-Remove a piercing card from a weapon or suit for 5,000,000 Penya. #b#cffff0000The removed card will be destroyed.#nc#nb
+﻿#b#cff0000ffソケットカードの削除#nb#nc
+武器またはスーツからソケットカードを5,000,000ペニャで削除します。#b#cffff0000取り外したカードは破壊されます。#nc#nb

--- a/Japanese/PrivacyNotice.txt
+++ b/Japanese/PrivacyNotice.txt
@@ -1,20 +1,20 @@
-﻿Welcome to #b#cffffdd66Flyff Universe#nc#nb!
+﻿#b#cffffdd66Flyff Universe#nc#nbへようこそ！
 
-Please note that the game translations are managed by the community and may contain inaccuracies. As of today only the #bEnglish version of the game shall be used as a reference#nb regarding item descriptions.
+ゲーム内の翻訳はコミュニティによって管理されており、不正確な内容が含まれる場合があります。現時点では、アイテムの説明に関しては#b英語版のゲームを基準としてご参照ください#nb。
 
-#bPrivacy Policy#nb: https://galalab.helpshift.com/a/flyff-universe/?s=tos-privacy-policy&f=privacy-policy
+#bプライバシーポリシー#nb：https://galalab.helpshift.com/a/flyff-universe/?s=tos-privacy-policy&f=privacy-policy
 
-#bTerms of Service#nb: https://galalab.helpshift.com/a/flyff-universe/?s=tos-privacy-policy&f=terms-of-service
+#b利用規約#nb：https://galalab.helpshift.com/a/flyff-universe/?s=tos-privacy-policy&f=terms-of-service
 
-You can find a link to these terms using the "Support" button in game.
+ゲーム内の「サポート」ボタンから、これらの規約へのリンクをご確認いただけます。
 
-This program #bcollects users datas#nb for its efficiency and safety.
+本プログラムは、効率性と安全性のために#bユーザーのデータを収集します#nb。
 
-Are collected: your IP address, your login and logout dates, datas linked to your virtual characters (name, location, inventory...). The datas are saved on a secured server under the responsibility of #bGala Lab Corp#nb. In case of any question or request concerning datas' removal, please, use the following address:
-#bgala.mobilegame@galaglobal.com#nb.
+収集される情報は、IPアドレス、ログイン・ログアウト日時、仮想キャラクターに関連するデータ（名前、位置情報、インベントリ等）です。これらのデータは、#bGala Lab Corp#nbの責任のもと、セキュリティで保護されたサーバーに保存されます。データの削除に関するご質問・ご依頼がある場合は、以下の宛先までご連絡ください：
+#bgala.mobilegame@galaglobal.com#nb。
 
-This website also use the persistent memory of your computer in order to store your session ID and your display preferences. In case you feel the need to, you may delate those datas without any further consequences.
+本ウェブサイトは、セッションIDや表示設定を保存するために、お使いのコンピューターの永続的なメモリも使用します。必要と感じられた場合は、それ以上の影響なくこれらのデータを削除することができます。
 
-Through this website you may communicate with other users. Any comments not aligned to Korean law, including but not limited to racists, homophobic, harassment and discriminatory comments are strictly forbidden. In case of non-respect of those rules, moderators take the right of immediate removal or block of your character, and even to forbid the access to the server from your IP address.
+本ウェブサイトを通じて、他のユーザーと交流することができます。人種差別、同性愛嫌悪、嫌がらせ、差別的な発言を含む（ただしこれらに限らない）、韓国の法律に反するコメントは固く禁止されています。これらのルールに違反した場合、モデレーターはキャラクターの即時削除・凍結、さらにはお使いのIPアドレスからのサーバーへのアクセス禁止を行う権利を有します。
 
-By clicking on the button #cffffdd66Accept#nc you certify you learned of the mentions above and accept it.
+#cffffdd66同意する#ncボタンをクリックすることで、上記の内容を確認し、同意したことを証明するものとします。

--- a/Japanese/Prologue.txt
+++ b/Japanese/Prologue.txt
@@ -1,73 +1,73 @@
-﻿The Story of Madrigal and the Three Clown Gods
+﻿マドリガルと三柱の道化の神々の物語
 
-#cffe4b100Chapter 1
-#b-Birth-#nb#nc
+#cffe4b100第1章
+#b-誕生-#nb#nc
 
-There were once five beings of limitless power who, struck by a strange whim,
-decided to create a world filled with magic and inexhaustible energy.
-They gathered together and laid the foundations that would define the world they were to build.
+かつて、無限の力を持つ五柱の存在がいた。ある日、彼らは奇妙な気まぐれに駆られ、
+魔法と尽きることのないエネルギーに満ちた世界を創ることを決意した。
+彼らは集い、これから築く世界の礎となる土台を築き上げた。
 
--They created Water, so life could flourish-
--They created Wind, so life could breathe-
--They created Earth, so life could grow-
--They created Fire, to temper the souls of the world's inhabitants-
--They created Lightning, to remind those who gazed at the skies that they were not alone-
+―生命が育つように、彼らは水を創った―
+―生命が息づくように、彼らは風を創った―
+―生命が育まれるように、彼らは大地を創った―
+―世界の住人たちの魂を鍛えるために、彼らは火を創った―
+―空を見上げる者たちに、独りではないと知らしめるために、彼らは雷を創った―
 
-#cffe4b100Chapter 2
-#b-Rhisis-#nb#nc
+#cffe4b100第2章
+#b-リシス-#nb#nc
 
-Life in the world known as Roika was prosperous for a long time.
-Its inhabitants spread across the continent as the Human race flourished.
-The Creators smiled upon the life they had shaped and continued to bless the people of Roika.
+ロイカと呼ばれるこの世界での暮らしは、長きにわたり繁栄を極めた。
+人間族が栄えるにつれ、その民は大陸中へと広がっていった。
+創造主たちは、自らが形作った生命に微笑みかけ、ロイカの民を祝福し続けた。
 
-In time, Humans grew lonely and begged the Creators to grant them companions-
-friends they could rely on in moments of hardship.
-Answering their plea, the Creators brought the Dwarpets to life.
-Together, Humans and Dwarpets shaped the world and lived in harmony
-for many generations.
+やがて、人間たちは孤独を感じるようになり、創造主たちに仲間を―
+苦難の時に頼れる友を与えてほしいと願い出た。
+その願いに応え、創造主たちはドワーフに命を吹き込んだ。
+人間とドワーフはともに世界を形作り、
+幾世代にもわたって調和の中で暮らした。
 
-Eventually, the Creators grew weary of watching over the world they had made.
-They prepared to leave Roika forever and return home.
-Humans and Dwarpets begged them to stay.
-"Sadly," the Creators replied, "we cannot. But we will leave someone to watch over you."
-And so, the Creators brought forth Rhisis and entrusted her with the duty
-of protecting all life on Roika.
+やがて創造主たちは、自らが創った世界を見守り続けることに疲れを覚えるようになった。
+彼らはロイカを永遠に去り、故郷へと帰る準備を始めた。
+人間とドワーフは、彼らに留まるよう懇願した。
+創造主たちは答えた。「悲しいことだが、それはできない。だが、お前たちを見守る者を残していこう」
+こうして創造主たちはリシスを生み出し、
+ロイカの全ての生命を守るという使命を彼女に託した。
 
-Rhisis safeguarded the world for thousands of years, yet with each passing year, her loneliness deepened.
-The pain of being left behind slowly consumed her heart.
+リシスは幾千年もの間この世界を守り続けたが、年月を重ねるごとに彼女の孤独は深まっていった。
+取り残された痛みが、ゆっくりと彼女の心をむしばんでいった。
 
-#cffe4b100Chapter 3
-#b-War of the Gods-#nb#nc
+#cffe4b100第3章
+#b-神々の戦争-#nb#nc
 
-From three aspects of her own being, Rhisis created the Three Clown Gods.
+リシスは、自らの存在から三つの側面を切り離し、三柱の道化の神を創り出した。
 
-She created Bubble, who embodied her joy and purity.
-She created Shade, who embodied her fear and rage.
-She created Iblis, who embodied her apathy.
+歓喜と純粋さを体現するバブルを創った。
+恐怖と怒りを体現するシェードを創った。
+無関心を体現するイブリスを創った。
 
-Shade, feeding upon Rhisis' anger, sought to destroy Roika and all who lived upon it.
-In her fury, she tore away a portion of the continent and cast it adrift.
-She hoped the people stranded there would soon perish.
+シェードはリシスの怒りを糧とし、ロイカとそこに住む全ての者を滅ぼそうとした。
+その激しい怒りの中で、彼女は大陸の一部を引き裂き、漂流させた。
+そこに取り残された人々が、やがて滅びることを彼女は望んでいた。
 
-That severed land came to be known as Madrigal.
-With the aid of the Dwarpets, the surviving Humans rebuilt their cities
-and once again began to thrive.
+その切り離された地は、後にマドリガルと呼ばれるようになった。
+ドワーフたちの助けを借りて、生き残った人間たちは都市を再建し、
+再び繁栄を始めた。
 
-Enraged by her failure, Shade created a race of monsters known as Masquerpets
-and sent them forth to annihilate the people of Madrigal.
-Hearing the echoes of battle far below, Bubble knew he could not remain idle.
-He struck the Masquerpets with tremendous force, splitting Madrigal into
-three great continents and scattering the Masquerpets across them.
+失敗に激怒したシェードは、モンスターと呼ばれる魔物の種族を創り出し、
+マドリガルの民を根絶やしにするために送り込んだ。
+はるか下方から響く戦いの音を聞き、バブルはもはや傍観していられないと悟った。
+彼はモンスターたちを凄まじい力で打ち据え、マドリガルを
+三つの大陸に分裂させ、モンスターたちをその各地へと散らせた。
 
-Iblis watched - and did nothing.
+イブリスはただそれを見つめ―そして何もしなかった。
 
-Ancient tales speak of eight Heroes who rose against Shade and her Masquerpet army.
-It is said they sacrificed their own lives to protect the people of Madrigal.
+古い伝承は、シェードとそのモンスターの軍勢に立ち向かった八人の英雄について語っている。
+彼らはマドリガルの民を守るため、自らの命を犠牲にしたと伝えられている。
 
-#cffe4b100Chapter 4
-#b-Re-Birth-#nb#nc
+#cffe4b100第4章
+#b-再誕-#nb#nc
 
-The people of Madrigal grew strong, yet they never forgot the friends and family
-left behind on Roika.
-They now train relentlessly to face Shade's Masquerpets, preparing for the day...
-...when Shade returns to destroy them all.
+マドリガルの民は強く育っていったが、
+ロイカに残してきた友や家族のことを決して忘れなかった。
+彼らは今もなお、シェードのモンスターたちに立ち向かうべく絶え間なく鍛錬を続け、その日に備えている……
+……シェードが戻り、全てを滅ぼし尽くす、その日に。

--- a/Japanese/RainbowRaceInfo.txt
+++ b/Japanese/RainbowRaceInfo.txt
@@ -1,12 +1,12 @@
-﻿#b Rainbow Race Information #nb
-Rainbow Race is an interactive and intense flying competition open to all players.
-Participants must use their own flying mount during the race.
+﻿#b レインボーレース情報 #nb
+レインボーレースは、全プレイヤーが参加できるインタラクティブで白熱した飛行競技です。
+レース参加者は、各自の飛行マウントを使用する必要があります。
 
-#iNote: The application fee is non-refundable. Each player must provide their own flying mount.#ni
+#i注意：参加費は返金されません。各プレイヤーは自身の飛行マウントを用意する必要があります。#ni
 
-Rewards:
-  - First Place: Title, Mount, and Rainbow Race First Place Box.
-  - Second Place: Rainbow Race Second Place Box.
-  - Third Place: Rainbow Race Third Place Box.
-  - Fourth to Tenth Place: Rainbow Race Honorable Box.
-  - All Other Participants: Participation Reward.
+報酬：
+  - 1位：称号、マウント、レインボーレース1位ボックス
+  - 2位：レインボーレース準優勝ボックス
+  - 3位：レインボーレース3位ボックス
+  - 4〜10位：レインボーレース佳作ボックス
+  - その他の参加者全員：参加報酬

--- a/Japanese/RainbowRaceRules.txt
+++ b/Japanese/RainbowRaceRules.txt
@@ -1,9 +1,9 @@
-﻿#b Rainbow Race Rules #nb
-1. Only players who have registered for the Rainbow Race can participate.
+﻿#b レインボーレースルール #nb
+1. レインボーレースに登録したプレイヤーのみが参加できます。
 
-2. The objective of the race is to follow a designated course, pass through Point Circles to earn points, and finish as quickly as possible.
+2. レースの目的は、指定されたコースに沿って進み、ポイントサークルを通過してポイントを獲得しながら、できるだけ早くゴールすることです。
 
-3. During the Rainbow Race, passing through Point Circles containing item boxes grants items that can be used to attack other players or protect yourself.
-  - Items in your inventory cannot be used during the race.
+3. レインボーレース中、アイテムボックスを含むポイントサークルを通過すると、他のプレイヤーを攻撃したり自分を守ったりするのに使えるアイテムを獲得できます。
+  - レース中はインベントリ内のアイテムを使用できません。
 
-4. Only players who are online at the start of the Rainbow Race may participate.
+4. レインボーレース開始時にオンラインだったプレイヤーのみが参加できます。

--- a/Japanese/SecretRoom.txt
+++ b/Japanese/SecretRoom.txt
@@ -1,15 +1,15 @@
-﻿Welcome, adventurers! Can you complete the Secret Room with #bup to 23 other guild members#nb? Each week, the top-ranked guilds will receive #bSecret Room Reward Boxes#nb!
+﻿ようこそ、冒険者よ！他のギルドメンバー最大23人と共に#bシークレットルーム#nbをクリアできるか？毎週、上位ランクのギルドには#bシークレットルーム報酬ボックス#nbが贈られる！
 
-Any guild that defeats Asmodan also has a small chance to obtain #bAsmodan clothes#nb and #bAsmodan weapon skins#nb.
+ルシファーを倒したギルドには、#bアスモダンの衣装#nbと#bアスモダンの武器スキン#nbを獲得できる小さなチャンスもある。
 
-Please note that the same guild can be ranked multiple times. The creator will receive the following rewards by mail:
-- 1st Place Guild: 85x Secret Room Reward Box
-- 2nd Place Guild: 60x Secret Room Reward Box
-- 3rd Place Guild: 35x Secret Room Reward Box
-- 4th Place Guild: 20x Secret Room Reward Box
-- 5th Place Guild: 10x Secret Room Reward Box
+同じギルドが複数回ランクインすることも可能です。ギルドの作成者には、以下の報酬がメールで送られます：
+- 1位ギルド：シークレットルーム報酬ボックス85個
+- 2位ギルド：シークレットルーム報酬ボックス60個
+- 3位ギルド：シークレットルーム報酬ボックス35個
+- 4位ギルド：シークレットルーム報酬ボックス20個
+- 5位ギルド：シークレットルーム報酬ボックス10個
 
-Contents of the #bSecret Room Reward Box#nb:
-- 1x 6 hours Tower Ticket
-- 8x Green Chips
-- 80x Blue Chips
+#bシークレットルーム報酬ボックス#nbの中身：
+- 6時間タワーチケット1個
+- グリーンチップ8個
+- ブルーチップ80個

--- a/Japanese/StoryDungeon.txt
+++ b/Japanese/StoryDungeon.txt
@@ -1,7 +1,7 @@
-﻿Welcome, adventurers! #bStory Mode#nb dungeons feature monsters with reduced attack, health, and experience compared to the normal dungeon difficulty.
+﻿ようこそ、冒険者よ！#bストーリーモード#nbダンジョンでは、通常のダンジョン難易度と比較して、モンスターの攻撃力・体力・経験値が低く設定されています。
 
-Story Mode is ideal for completing quests with friends or enjoying a relaxed walkthrough of the scenario in a #blow-risk#nb environment. Enjoy!
+ストーリーモードは、友達とクエストをクリアしたり、#bリスクの低い#nb環境でシナリオをゆったりと進めたりするのに最適です。楽しんでください！
 
-- Masquerpets in Story Mode dungeons do not drop items.
-- Pet cages and treasure chests do not spawn in Story Mode.
-- Players do not earn achievement progress in Story Mode.
+- ストーリーモードダンジョンのモンスターはアイテムをドロップしません。
+- ストーリーモードでは、ペットケージや宝箱は出現しません。
+- ストーリーモードでは、実績の進捗は獲得できません。

--- a/Japanese/UltimateJewelRemove.txt
+++ b/Japanese/UltimateJewelRemove.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ffRemove Ultimate Jewel#nb#nc
-Remove an ultimate jewel from an item for 5,000,000 Penya. #b#cffff0000Without Jewel Tweezers, the jewel will be destroyed.#nc#nb
+﻿#b#cff0000ffアルティマジュエルの削除#nb#nc
+アイテムからアルティマジュエルを5,000,000ペニャで削除します。#b#cffff0000ジュエルツイーザーがない場合、ジュエルは破壊されます。#nc#nb

--- a/Japanese/Unbinding.txt
+++ b/Japanese/Unbinding.txt
@@ -1,5 +1,5 @@
-﻿The cost of unbinding is 100,000 Penya per item.
-#cffff0000Unbinding will remove #ball upgrades, bonuses, element and piercings#nb.
-You cannot cancel the operation once it is done.#nc
-The item will be tradable again. If you want to keep all improvements, please use a Scroll of Unbinding instead of this menu.
-Only works on Soul-Bound items and #bnot Soul-Linked items#nb.
+﻿帰属解除の費用は、アイテム1つにつき100,000ペニャです。
+#cffff0000帰属を解除すると、#bすべての強化、ボーナス、属性、ソケット#nbが失われます。
+この操作は、一度実行すると取り消せません。#nc
+アイテムは再び取引可能になります。強化内容をすべて維持したい場合は、このメニューではなく帰属解除の巻物をご使用ください。
+この機能は、キャラクター帰属のアイテムにのみ使用でき、#bプレイヤーに帰属しているアイテムには使用できません#nb。

--- a/Japanese/WeaponConvert_Gem.txt
+++ b/Japanese/WeaponConvert_Gem.txt
@@ -1,7 +1,7 @@
-﻿#b#cff0000ff Necessary gem for each level #nb#nc
-  60~70 : Topaz
-  71~85 : Ruby
- 86~100 : Sapphire
-101~119 : Emerald
-120~140 : Diamond
-141~160 : Amethyst, Brilliant Amethyst
+﻿#b#cff0000ff レベルごとに必要な宝石 #nb#nc
+  60~70 : トパーズ
+  71~85 : ルビー
+ 86~100 : サファイア
+101~119 : エメラルド
+120~140 : ダイヤモンド
+141~160 : アメジスト、ブリリアントアメジスト

--- a/Japanese/WeaponConvert_Unique.txt
+++ b/Japanese/WeaponConvert_Unique.txt
@@ -1,2 +1,2 @@
-﻿#b#cff0000ff Unique Weapon Conversion #nb#nc
-You can convert a normal weapon (level 60 or higher required to wield) into a Unique weapon by using 1 Jewel corresponding to the weapon's required level and 1 Shining Power Dice. If the conversion fails, all materials are destroyed.
+﻿#b#cff0000ff ユニーク武器への変換 #nb#nc
+必要レベル60以上の通常武器は、その武器の必要レベルに対応する宝石1個と、輝くパワーダイス1個を使用することで、ユニーク武器に変換できます。変換に失敗すると、全ての素材が消滅します。


### PR DESCRIPTION
## Description
Translates all previously English-only `.txt` files in `Japanese/` into Japanese, so every file in `Japanese/*.txt` now has Japanese content matching the `English_Reference` structure and line counts. No keys/structure changed, only translation text added.

## Checklist
- [x] All edited files are UTF-8 encoded (with BOM, CRLF, matching existing convention)
- [x] No translation entries added, removed, or reordered
- [x] Only translation text was edited (translated previously untranslated English text)
- [x] No keys, structure, or formatting were changed
- [x] I have read and agree to the terms of CLA.md