### PR TITLE
Fix French translations for characters in Movers.csv

### DIFF
--- a/French/Movers.csv
+++ b/French/Movers.csv
@@ -1576,26 +1576,26 @@ PROPMOVER_TXT_505002,[Forgotten] Drifter,[Oublié] Vagabond
 PROPMOVER_TXT_505003,[Forgotten] Captain Drifter,[Oublié] Capitaine Vagabond
 PROPMOVER_TXT_505004,[Forgotten] Giant Drifter,[Oublié] Vagabond géant
 PROPMOVER_TXT_505005,[Forgotten] Great Drifter,[Oublié] Grand Vagabond
-PROPMOVER_TXT_505006,[Forgotten] Small Maiden,[Oublié] Petite Nomade
-PROPMOVER_TXT_505007,[Forgotten] Maiden,[Oublié] Nomade
-PROPMOVER_TXT_505008,[Forgotten] Captain Maiden,[Oublié] Capitaine Nomade
-PROPMOVER_TXT_505009,[Forgotten] Giant Maiden,[Oublié] Nomade Géante
-PROPMOVER_TXT_505010,[Forgotten] Great Maiden,[Oublié] Grande Nomade
+PROPMOVER_TXT_505006,[Forgotten] Small Maiden,[Oubliée] Petite Nomade
+PROPMOVER_TXT_505007,[Forgotten] Maiden,[Oubliée] Nomade
+PROPMOVER_TXT_505008,[Forgotten] Captain Maiden,[Oubliée] Capitaine Nomade
+PROPMOVER_TXT_505009,[Forgotten] Giant Maiden,[Oubliée] Nomade Géante
+PROPMOVER_TXT_505010,[Forgotten] Great Maiden,[Oubliée] Grande Nomade
 PROPMOVER_TXT_505011,[Forgotten] Small Reaver,[Oublié] Petit Ravageur
 PROPMOVER_TXT_505012,[Forgotten] Reaver,[Oublié] Ravageur
 PROPMOVER_TXT_505013,[Forgotten] Captain Reaver,[Oublié] Capitaine Ravageur
 PROPMOVER_TXT_505014,[Forgotten] Giant Reaver,[Oublié] Ravageur géant
 PROPMOVER_TXT_505015,[Forgotten] Great Reaver,[Oublié] Grand Ravageur
-PROPMOVER_TXT_505016,[Forgotten] Small Mystica,[Oublié] Petite Enchanteresse
-PROPMOVER_TXT_505017,[Forgotten] Mystica,[Oublié] Enchanteresse
-PROPMOVER_TXT_505018,[Forgotten] Captain Mystica,[Oublié] Capitaine Enchanteresse
-PROPMOVER_TXT_505019,[Forgotten] Giant Mystica,[Oublié] Enchanteresse géante
-PROPMOVER_TXT_505020,[Forgotten] Great Mystica,[Oublié] Grande Enchanteresse
-PROPMOVER_TXT_505021,[Forgotten] Small Anae,[Oublié] Petite Prêtresse
-PROPMOVER_TXT_505022,[Forgotten] Anae,[Oublié] Prêtresse
-PROPMOVER_TXT_505023,[Forgotten] Captain Anae,[Oublié] Capitaine Prêtresse
-PROPMOVER_TXT_505024,[Forgotten] Giant Anae,[Oublié] Prêtresse géante
-PROPMOVER_TXT_505025,[Forgotten] Great Anae,[Oublié] Grande Prêtresse
+PROPMOVER_TXT_505016,[Forgotten] Small Mystica,[Oubliée] Petite Enchanteresse
+PROPMOVER_TXT_505017,[Forgotten] Mystica,[Oubliée] Enchanteresse
+PROPMOVER_TXT_505018,[Forgotten] Captain Mystica,[Oubliée] Capitaine Enchanteresse
+PROPMOVER_TXT_505019,[Forgotten] Giant Mystica,[Oubliée] Enchanteresse géante
+PROPMOVER_TXT_505020,[Forgotten] Great Mystica,[Oubliée] Grande Enchanteresse
+PROPMOVER_TXT_505021,[Forgotten] Small Anae,[Oubliée] Petite Prêtresse
+PROPMOVER_TXT_505022,[Forgotten] Anae,[Oubliée] Prêtresse
+PROPMOVER_TXT_505023,[Forgotten] Captain Anae,[Oubliée] Capitaine Prêtresse
+PROPMOVER_TXT_505024,[Forgotten] Giant Anae,[Oubliée] Prêtresse géante
+PROPMOVER_TXT_505025,[Forgotten] Great Anae,[Oubliée] Grande Prêtresse
 PROPMOVER_TXT_505026,[Forgotten] Small Rifter,[Oublié] Petit rôdeur
 PROPMOVER_TXT_505027,[Forgotten] Rifter,[Oublié] Rôdeur
 PROPMOVER_TXT_505028,[Forgotten] Captain Rifter,[Oublié] Capitaine rôdeur


### PR DESCRIPTION
Updated French translations for various characters, changing 'Oublié' to 'Oubliée' where appropriate.

### Description
Briefly describe the changes made in this pull request.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
