### PR TITLE
[German] Fix item names

### DIFF
--- a/English_Reference/Items.csv
+++ b/English_Reference/Items.csv
@@ -29256,7 +29256,7 @@ PROPITEM_TXT_913775,A sacred targe infused with a fragment of Entaness' lingerin
 PROPITEM_TXT_913776,Sword of Whisper
 PROPITEM_TXT_913777,Sword of Mist
 PROPITEM_TXT_913778,Phantasmal Slayer
-PROPITEM_TXT_913779,Specter's Axe 
+PROPITEM_TXT_913779,Specter's Axe
 PROPITEM_TXT_913780,Cleaver of the Mist
 PROPITEM_TXT_913781,Knuckle of Madness
 PROPITEM_TXT_913782,Mirage

--- a/German/Items.csv
+++ b/German/Items.csv
@@ -26603,17 +26603,17 @@ PROPITEM_TXT_903693,Rose Pink Yukata Costume Set Select Box,Rose Pink Yukata Cos
 PROPITEM_TXT_903694,Select which Gender you want to receive!,Select which Gender you want to receive!
 PROPITEM_TXT_155827,[Event] 2026 Spring Gift Box,[Event] 2026 Spring Gift Box
 PROPITEM_TXT_155828,Madrigal Flying Selection Box (15 days),Madrigal Flying Selection Box (15 days)
-PROPITEM_TXT_155829,2026 FWC Golden Curtana Ultimate,2026 FWC Golden Curtana Ultimate
-PROPITEM_TXT_155830,2026 FWC Golden Celestial Edge Ultimate,2026 FWC Golden Celestial Edge Ultimate
-PROPITEM_TXT_155831,2026 FWC Golden Butcher's Carnage Ultimate,2026 FWC Golden Butcher's Carnage Ultimate
-PROPITEM_TXT_155832,2026 FWC Golden Harbinger Ultimate,2026 FWC Golden Harbinger Ultimate
-PROPITEM_TXT_155833,2026 FWC Golden Maw of Judgement Ultimate,2026 FWC Golden Maw of Judgement Ultimate
-PROPITEM_TXT_155834,2026 FWC Golden Oracle Ultimate,2026 FWC Golden Oracle Ultimate
-PROPITEM_TXT_155835,2026 FWC Golden Scepter of Disorder Ultimate,2026 FWC Golden Scepter of Disorder Ultimate
-PROPITEM_TXT_155836,2026 FWC Golden Roika's Stave Ultimate,2026 FWC Golden Roika's Stave Ultimate
-PROPITEM_TXT_155837,2026 FWC Golden Dementia Ultimate,2026 FWC Golden Dementia Ultimate
-PROPITEM_TXT_155838,2026 FWC Golden Dragon's Rain Ultimate,2026 FWC Golden Dragon's Rain Ultimate
-PROPITEM_TXT_155839,2026 FWC Golden K Fang Ultimate,2026 FWC Golden K Fang Ultimate
+PROPITEM_TXT_155829,2026 FWC Golden Curtana Ultimate,2026 FWC Golden Curtana
+PROPITEM_TXT_155830,2026 FWC Golden Celestial Edge Ultimate,2026 FWC Golden Celestial Edge
+PROPITEM_TXT_155831,2026 FWC Golden Butcher's Carnage Ultimate,2026 FWC Golden Butcher's Carnage
+PROPITEM_TXT_155832,2026 FWC Golden Harbinger Ultimate,2026 FWC Golden Harbinger
+PROPITEM_TXT_155833,2026 FWC Golden Maw of Judgement Ultimate,2026 FWC Golden Maw of Judgement
+PROPITEM_TXT_155834,2026 FWC Golden Oracle Ultimate,2026 FWC Golden Oracle
+PROPITEM_TXT_155835,2026 FWC Golden Scepter of Disorder Ultimate,2026 FWC Golden Scepter of Disorder
+PROPITEM_TXT_155836,2026 FWC Golden Roika's Stave Ultimate,2026 FWC Golden Roika's Staff
+PROPITEM_TXT_155837,2026 FWC Golden Dementia Ultimate,2026 FWC Golden Dementia
+PROPITEM_TXT_155838,2026 FWC Golden Dragon's Rain Ultimate,2026 FWC Golden Dragon's Rain
+PROPITEM_TXT_155839,2026 FWC Golden K Fang Ultimate,2026 FWC Golden K Fang
 PROPITEM_TXT_155840,2026 FWC Golden Runthiel Helmet,2026 FWC Golden Runthiel Helmet
 PROPITEM_TXT_155841,2026 FWC Golden Runthiel Suit,2026 FWC Golden Runthiel Suit
 PROPITEM_TXT_155842,2026 FWC Golden Runthiel Gauntlets,2026 FWC Golden Runthiel Gauntlets
@@ -29256,25 +29256,25 @@ PROPITEM_TXT_913775,A sacred targe infused with a fragment of Entaness' lingerin
 PROPITEM_TXT_913776,Sword of Whisper,Sword of Whisper
 PROPITEM_TXT_913777,Sword of Mist,Sword of Mist
 PROPITEM_TXT_913778,Phantasmal Slayer,Phantasmal Slayer
-PROPITEM_TXT_913779,Specter's Axe ,Specter's Axe 
-PROPITEM_TXT_913780,Clever of the mist,Clever of the mist
+PROPITEM_TXT_913779,Specter's Axe ,Specter's Axe
+PROPITEM_TXT_913780,Clever of the mist,Cleaver of the Mist
 PROPITEM_TXT_913781,Knuckle of Madness,Knuckle of Madness
 PROPITEM_TXT_913782,Mirage,Mirage
-PROPITEM_TXT_913783,Wand of apparitions,Wand of apparitions
+PROPITEM_TXT_913783,Wand of apparitions,Wand of Apparitions
 PROPITEM_TXT_913784,Staff of Ethereal Dreams,Staff of Ethereal Dreams
 PROPITEM_TXT_913785,Bow of Echoes,Bow of Echoes
 PROPITEM_TXT_913786,Jewel of Nightmare,Jewel of Nightmare
-PROPITEM_TXT_913787,Sword of Whisper Ultimate,Sword of Whisper Ultimate
-PROPITEM_TXT_913788,Sword of Mist Ultimate,Sword of Mist Ultimate
-PROPITEM_TXT_913789,Phantasmal Slayer Ultimate,Phantasmal Slayer Ultimate
-PROPITEM_TXT_913790,Specter's Axe Ultimate,Specter's Axe Ultimate
-PROPITEM_TXT_913791,Clever of the mist Ultimate,Clever of the mist Ultimate
-PROPITEM_TXT_913792,Knuckle of Madness Ultimate,Knuckle of Madness Ultimate
-PROPITEM_TXT_913793,Mirage Ultimate,Mirage Ultimate
-PROPITEM_TXT_913794,Wand of apparitions Ultimate,Wand of apparitions Ultimate
-PROPITEM_TXT_913795,Staff of Ethereal Dreams Ultimate,Staff of Ethereal Dreams Ultimate
-PROPITEM_TXT_913796,Bow of Echoes Ultimate,Bow of Echoes Ultimate
-PROPITEM_TXT_913797,Jewel of Nightmare Ultimate,Jewel of Nightmare Ultimate
+PROPITEM_TXT_913787,Sword of Whisper Ultimate,Sword of Whisper
+PROPITEM_TXT_913788,Sword of Mist Ultimate,Sword of Mist
+PROPITEM_TXT_913789,Phantasmal Slayer Ultimate,Phantasmal Slayer
+PROPITEM_TXT_913790,Specter's Axe Ultimate,Specter's Axe
+PROPITEM_TXT_913791,Clever of the mist Ultimate,Cleaver of the Mist
+PROPITEM_TXT_913792,Knuckle of Madness Ultimate,Knuckle of Madness
+PROPITEM_TXT_913793,Mirage Ultimate,Mirage
+PROPITEM_TXT_913794,Wand of apparitions Ultimate,Wand of Apparitions
+PROPITEM_TXT_913795,Staff of Ethereal Dreams Ultimate,Staff of Ethereal Dreams
+PROPITEM_TXT_913796,Bow of Echoes Ultimate,Bow of Echoes
+PROPITEM_TXT_913797,Jewel of Nightmare Ultimate,Jewel of Nightmare
 PROPITEM_TXT_913798,1.5.5 Update Pass,1.5.5 Update Pass
 PROPITEM_TXT_913799,This purchase will give you access to many advantages until the end of the 1.5.5 Update Pass season,This purchase will give you access to many advantages until the end of the 1.5.5 Update Pass season
 PROPITEM_TXT_913800,1.5.5 Update Lucky Box,1.5.5 Update Lucky Box

--- a/German/Items.csv
+++ b/German/Items.csv
@@ -24550,7 +24550,7 @@ PROPITEM_TXT_155501,Veil of Shade,Veil of Shade
 PROPITEM_TXT_155502,Maw of Judgement,Maw of Judgement
 PROPITEM_TXT_155503,Oracle,Behemoth's Stick
 PROPITEM_TXT_155504,Scepter of Disorder,Scepter of Disorder
-PROPITEM_TXT_155505,Roika's Stave,Roika's Stave
+PROPITEM_TXT_155505,Roika's Stave,Roika's Staff
 PROPITEM_TXT_155506,Curtana,Curtana
 PROPITEM_TXT_155507,Celestial Edge,Celestial Edge
 PROPITEM_TXT_155508,Bringer of Souls,Bringer of Souls
@@ -24574,10 +24574,10 @@ PROPITEM_TXT_155525,Broken Maw of Judgement,Broken Maw of Judgement
 PROPITEM_TXT_155526,Battle-Worn Maw of Judgement,Battle-Worn Maw of Judgement
 PROPITEM_TXT_155527,Cursed Maw of Judgement,Cursed Maw of Judgement
 PROPITEM_TXT_155528,Maw of Judgement,Maw of Judgement
-PROPITEM_TXT_155529,Broken Roika's Stave,Broken Roika's Stave
-PROPITEM_TXT_155530,Battle-Worn Roika's Stave,Battle-Worn Roika's Stave
-PROPITEM_TXT_155531,Cursed Roika's Stave,Cursed Roika's Stave
-PROPITEM_TXT_155532,Roika's Stave,Roika's Stave
+PROPITEM_TXT_155529,Broken Roika's Stave,Broken Roika's Staff
+PROPITEM_TXT_155530,Battle-Worn Roika's Stave,Battle-Worn Roika's Staff
+PROPITEM_TXT_155531,Cursed Roika's Stave,Cursed Roika's Staff
+PROPITEM_TXT_155532,Roika's Stave,Roika's Staff
 PROPITEM_TXT_155533,Broken Oracle,Broken Oracle
 PROPITEM_TXT_155534,Battle-Worn Oracle,Battle-Worn Oracle
 PROPITEM_TXT_155535,Cursed Oracle,Cursed Oracle


### PR DESCRIPTION
### Description
Fixes item names like it happened in english reference: https://github.com/Gala-Lab/Flyff-Universe-Translations/commit/60b191e1e2830a0e6d73db9dbbb6dabbf0ca4da8
Since the mentioned commit and mine changes english reference, the english phrased should synchronized to other languages as well

Note: This removes a whitespace from "Specter's Axe " in english reference

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
