### PR TITLE
[Japanese] Translate The Last Beacon (Wave Defense) content

### DIFF
--- a/Japanese/Controls.csv
+++ b/Japanese/Controls.csv
@@ -716,4 +716,4 @@ PROPCTRL_TXT_000739,3rd Anniversary Flaris Cake,3周年記念フラリスケー�
 PROPCTRL_TXT_000740,3rd Anniversary Saint Morning Cake,3周年記念セイントモーニングケーキ
 PROPCTRL_TXT_000741,3rd Anniversary Darkon Cake,3周年記念ダーコンケーキ
 PROPCTRL_TXT_000742,Dungeon Warp 07,ダンジョンワープ07
-PROPCTRL_TXT_000743,First Aid Kit,First Aid Kit
+PROPCTRL_TXT_000743,First Aid Kit,応急処置キット

--- a/Japanese/MoverMenus.csv
+++ b/Japanese/MoverMenus.csv
@@ -186,8 +186,8 @@ MMI_2030,PTS Exchange (Other Equipment),PTS交換(その他の装備)
 MMI_2031,Reset Cooldowns,クールダウンをリセット
 MMI_2032,PTS Exchange (New Equipment),PTS交換(新装備)
 MMI_2033,Item Exchange,アイテム交換
-MMI_1118,The Last Beacon,The Last Beacon
-MMI_1119,Re-join Last Beacon match,Re-join Last Beacon match
+MMI_1118,The Last Beacon,ザ・ラストビーコン
+MMI_1119,Re-join Last Beacon match,ザ・ラストビーコンのマッチに再参加
 MMI_1122,Lv165 GS Apply,Lv165 GS適用
 MMI_1123,Lv165 GS Status,Lv165 GSステータス
 MMI_1124,Lv165 GS Cancel,Lv165 GSキャンセル

--- a/Japanese/Skills.csv
+++ b/Japanese/Skills.csv
@@ -1225,5 +1225,5 @@ PROPSKILL_TXT_100203,Stun,Stun
 PROPSKILL_TXT_100204,You are stunned and cannot move.,You are stunned and cannot move.
 PROPSKILL_TXT_100205,Sand Shield,Sand Shield
 PROPSKILL_TXT_100206,Incoming damage is reduced to 1 for 5 seconds.,Incoming damage is reduced to 1 for 5 seconds.
-PROPSKILL_TXT_150642,Wave Defense Buff,Wave Defense Buff
-PROPSKILL_TXT_150643,"Reinforced by your fellow defenders. Increases Attack, Speed, Defense, and Max HP based on the number of defenders present.","Reinforced by your fellow defenders. Increases Attack, Speed, Defense, and Max HP based on the number of defenders present."
+PROPSKILL_TXT_150642,Wave Defense Buff,ウェーブディフェンスバフ
+PROPSKILL_TXT_150643,"Reinforced by your fellow defenders. Increases Attack, Speed, Defense, and Max HP based on the number of defenders present.","仲間の守備隊員によって強化される。生存中の守備隊員の数に応じて攻撃力、速度、防御力、最大HPが増加する。"

--- a/Japanese/UI.csv
+++ b/Japanese/UI.csv
@@ -3403,87 +3403,87 @@ UI_PVPCONTEST_REGISTRATION_LBLMINGUILDLEVEL_TOOLTIP,Minimum guild level,Minimum 
 UI_PVPCONTEST_REGISTRATION_LBLMINLEVEL,Min. Player Level,Min. Player Level
 UI_PVPCONTEST_REGISTRATION_LBLMINLEVEL_TOOLTIP,Minimum player level,Minimum player level
 UI_PVPCONTEST_REGISTRATION_LBLREGIONDETAIL,Region assigned based on active match schedule,Region assigned based on active match schedule
-UI_WAVEDEFENSE_TITLE,The Last Beacon,The Last Beacon
-UI_WAVEDEFENSE_CREATEMATCH,Create Match,Create Match
-UI_WAVEDEFENSE_JOINMATCH,Join Match,Join Match
-UI_WAVEDEFENSE_BTNMODEPUBLIC,Public,Public
-UI_WAVEDEFENSE_BTNMODEPRIVATE,Private,Private
-UI_WAVEDEFENSE_BTNCREATEMATCH,Create Match,Create Match
-UI_WAVEDEFENSE_BTNQUICKJOIN,Quick Join,Quick Join
-UI_WAVEDEFENSE_BTNJOIN,Join,Join
-UI_WAVEDEFENSE_LBLMODE,Mode,Mode
-UI_WAVEDEFENSE_LBLMATCH,Match,Match
-UI_WAVEDEFENSE_LBLSETTINGS,Game Settings,Game Settings
-UI_WAVEDEFENSE_LBLMATCHPASSWORD,Match password,Match password
-UI_WAVEDEFENSE_HDRMINLEVEL,Min. Level: %d,Min. Level: %d
-UI_WAVEDEFENSE_HDRMAXPLAYERS,Max Players: %d,Max Players: %d
-UI_WAVEDEFENSE_HDRWAVECOUNT,Waves Count: %d,Waves Count: %d
-UI_WAVEDEFENSE_LBLSEARCH,Room Name,Room Name
-UI_WAVEDEFENSE_CBBMODEPUBLIC,Public,Public
-UI_WAVEDEFENSE_CBBMODEPRIVATE,Private,Private
-UI_WAVEDEFENSE_LBLROOMNAME,Room Name,Room Name
-UI_WAVEDEFENSE_LBLROOMDETAILS,Room Details,Room Details
-UI_WAVEDEFENSE_LBLPLAYERCOUNT,Player Count,Player Count
-UI_WAVEDEFENSE_LBLSTARTINGIN,Starting in,Starting in
-UI_WAVEDEFENSE_LBLLEADER,Leader,Leader
-UI_WAVEDEFENSE_LBLPLAYERSCOMPOSITION,Players Composition,Players Composition
-UI_WAVEDEFENSE_CBBMODEALL,All ,All 
-UI_WAVEDEFENSEMATCHLIST_HDRROOMNAME,Room Name,Room Name
-UI_WAVEDEFENSEMATCHLIST_HDRMODE,Mode,Mode
-UI_WAVEDEFENSEMATCHLIST_HDRPLAYERCOUNT,Players,Players
-UI_WAVEDEFENSEMATCHLIST_HDRLEADER,Leader,Leader
-UI_WAVEDEFENSEMATCHLIST_HDRSTARTINGIN,Starting in,Starting in
-UI_WAVEDEFENSE_STATUS_CURRENTWAVE,Current Wave %d/%d,Current Wave %d/%d
-UI_WAVEDEFENSE_STATUS_TOTALTIME,Total time %s,Total time %s
-UI_WAVEDEFENSE_STATUS_DEFENDERSLEFT,Sailors %d/%d,Sailors %d/%d
-UI_WAVEDEFENSE_STATUS_MONSTERSLEFT,Monsters %d/%d,Monsters %d/%d
-UI_WAVEDEFENSE_STATUS_REWARDS,Rewards,Rewards
-UI_WAVEDEFENSE_STATUS_TIMELEFT_PREPARE,Starting in %s,Starting in %s
-UI_WAVEDEFENSE_STATUS_TIMELEFT_FIGHT,Time left %s,Time left %s
-UI_WAVEDEFENSE_STATUS_TIMELEFT_PREPAREWAVE,Prepare %s,Prepare %s
-UI_WAVEDEFENSE_STATUS_TIMELEFT_TELEPORT,Teleporting in %s,Teleporting in %s
-UI_WAVEDEFENSE_STATUS_FORCESTART,Start now,Start now
-UI_WAVEDEFENSE_STATUS_FORCENEXTWAVE,Next wave,Next wave
+UI_WAVEDEFENSE_TITLE,The Last Beacon,ザ・ラストビーコン
+UI_WAVEDEFENSE_CREATEMATCH,Create Match,マッチを作成
+UI_WAVEDEFENSE_JOINMATCH,Join Match,マッチに参加
+UI_WAVEDEFENSE_BTNMODEPUBLIC,Public,公開
+UI_WAVEDEFENSE_BTNMODEPRIVATE,Private,非公開
+UI_WAVEDEFENSE_BTNCREATEMATCH,Create Match,マッチを作成
+UI_WAVEDEFENSE_BTNQUICKJOIN,Quick Join,クイック参加
+UI_WAVEDEFENSE_BTNJOIN,Join,参加
+UI_WAVEDEFENSE_LBLMODE,Mode,モード
+UI_WAVEDEFENSE_LBLMATCH,Match,マッチ
+UI_WAVEDEFENSE_LBLSETTINGS,Game Settings,ゲーム設定
+UI_WAVEDEFENSE_LBLMATCHPASSWORD,Match password,マッチパスワード
+UI_WAVEDEFENSE_HDRMINLEVEL,Min. Level: %d,最低レベル：%d
+UI_WAVEDEFENSE_HDRMAXPLAYERS,Max Players: %d,最大参加人数：%d
+UI_WAVEDEFENSE_HDRWAVECOUNT,Waves Count: %d,ウェーブ数：%d
+UI_WAVEDEFENSE_LBLSEARCH,Room Name,ルーム名
+UI_WAVEDEFENSE_CBBMODEPUBLIC,Public,公開
+UI_WAVEDEFENSE_CBBMODEPRIVATE,Private,非公開
+UI_WAVEDEFENSE_LBLROOMNAME,Room Name,ルーム名
+UI_WAVEDEFENSE_LBLROOMDETAILS,Room Details,ルーム詳細
+UI_WAVEDEFENSE_LBLPLAYERCOUNT,Player Count,参加人数
+UI_WAVEDEFENSE_LBLSTARTINGIN,Starting in,開始まで
+UI_WAVEDEFENSE_LBLLEADER,Leader,リーダー
+UI_WAVEDEFENSE_LBLPLAYERSCOMPOSITION,Players Composition,参加者構成
+UI_WAVEDEFENSE_CBBMODEALL,All ,すべて
+UI_WAVEDEFENSEMATCHLIST_HDRROOMNAME,Room Name,ルーム名
+UI_WAVEDEFENSEMATCHLIST_HDRMODE,Mode,モード
+UI_WAVEDEFENSEMATCHLIST_HDRPLAYERCOUNT,Players,参加人数
+UI_WAVEDEFENSEMATCHLIST_HDRLEADER,Leader,リーダー
+UI_WAVEDEFENSEMATCHLIST_HDRSTARTINGIN,Starting in,開始まで
+UI_WAVEDEFENSE_STATUS_CURRENTWAVE,Current Wave %d/%d,現在のウェーブ %d/%d
+UI_WAVEDEFENSE_STATUS_TOTALTIME,Total time %s,合計時間 %s
+UI_WAVEDEFENSE_STATUS_DEFENDERSLEFT,Sailors %d/%d,船員 %d/%d
+UI_WAVEDEFENSE_STATUS_MONSTERSLEFT,Monsters %d/%d,モンスター %d/%d
+UI_WAVEDEFENSE_STATUS_REWARDS,Rewards,報酬
+UI_WAVEDEFENSE_STATUS_TIMELEFT_PREPARE,Starting in %s,開始まで %s
+UI_WAVEDEFENSE_STATUS_TIMELEFT_FIGHT,Time left %s,残り時間 %s
+UI_WAVEDEFENSE_STATUS_TIMELEFT_PREPAREWAVE,Prepare %s,準備 %s
+UI_WAVEDEFENSE_STATUS_TIMELEFT_TELEPORT,Teleporting in %s,転送まで %s
+UI_WAVEDEFENSE_STATUS_FORCESTART,Start now,今すぐ開始
+UI_WAVEDEFENSE_STATUS_FORCENEXTWAVE,Next wave,次のウェーブ
 UI_WAVEDEFENSE_LISTPLAYER_LEVEL,Lv.%d,Lv.%d
-UI_WAVEDEFENSE_LISTPLAYER_EMPTYSLOT,Empty Slot,Empty Slot
-UI_WAVEDEFENSE_STATUS_PASSWORD,Room password: %s,Room password: %s
-UI_WAVEDEFENSE_STATUS_KICK,Kick,Kick
-UI_WAVEDEFENSE_STATUS_KICKTITLE,Kick user,Kick user
-UI_WAVEDEFENSE_STATUS_KICKMSG,You are about to kick user %s. Do you want to continue?,You are about to kick user %s. Do you want to continue?
-UI_WAVEDEFENSE_STATUS_INVITETITLE,Invite user,Invite user
-UI_WAVEDEFENSE_STATUS_INVITEINFO,Please put the player name you want to invite in your Wave Defense match.,Please put the player name you want to invite in your Wave Defense match.
-UI_WAVEDEFENSE_STATUS_INVITEPLAYER,Player name,Player name
-UI_WAVEDEFENSE_JOIN_TITLE,Confirm Wave,Confirm Wave
-UI_WAVEDEFENSE_JOIN_MSG,%s invites you to join wave defense match. Accept the invitation?,%s invites you to join wave defense match. Accept the invitation?
-UI_WAVEDEFENSE_JOINMATCH_TITLE,Join Wave Defense Match,Join Wave Defense Match
-UI_WAVEDEFENSE_JOINMATCH_MSG,You are about to join match %s. Confirm?,You are about to join match %s. Confirm?
-UI_WAVEDEFENSE_JOINMATCH_PWD,Password,Password
-UI_WAVEDEFENSE_RANKING,Ranking,Ranking
-UI_WAVEDEFENSE_MILESTONE_HEADER,Milestones,Milestones
-UI_WAVEDEFENSE_MILESTONE_DESC,Clear waves with your team and claim exclusive rewards!,Clear waves with your team and claim exclusive rewards!
-UI_WAVEDEFENSE_MILESTONE,Clear %d total waves,Clear %d total waves
-UI_WAVEDEFENSE_RANKING_RANK,Rank,Rank
-UI_WAVEDEFENSE_RANKING_ROOM,Room Name,Room Name
-UI_WAVEDEFENSE_RANKING_WAVE,Max Wave,Max Wave
-UI_WAVEDEFENSE_RANKING_KILLS,Total Kills,Total Kills
-UI_WAVEDEFENSE_RANKING_DEFENDERS,Sailors,Sailors
-UI_WAVEDEFENSE_RANKING_TIME,Time,Time
-UI_WAVEDEFENSE_MILESTONE_CLAIM,Claim,Claim
-UI_WAVEDEFENSE_RANKING_DESC,Dominate the rankings with your team and secure your place at the top!,Dominate the rankings with your team and secure your place at the top!
-UI_WAVEDEFENSE_RANKINGDETAILS_HDR,Match Details,Match Details
-UI_WAVEDEFENSE_RANKINGDETAILS_ROOMNAME,Room Name,Room Name
-UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_NAME,Player,Player
-UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_JOB,Job,Job
-UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_KILLS,Kills,Kills
-UI_WAVEDEFENSE_STATUS_RESPAWN,Respawn in %s,Respawn in %s
-UI_PVPMATCH_RESPAWNNOW,Respawn now,Respawn now
-UI_WAVEDEFENSE_INVITATION_INVITE,Invite,Invite
-UI_WAVEDEFENSE_INVITATION_CLOSE,Close,Close
-UI_WAVEDEFENSE_HDRDAILYMATCHES,Daily matches: %d/%d,Daily matches: %d/%d
-UI_WAVEDEFENSE_SKIPWAVE_CONFIRM,Skip the remaining wait and start the next wave now?,Skip the remaining wait and start the next wave now?
-UI_WAVEDEFENSE_CLEARREWARD_MAXEDTODAY,Already claimed today. Resets tomorrow.,Already claimed today. Resets tomorrow.
-UI_WAVEDEFENSE_STATUS_IMMORTAL,Immortal Sailors Enabled,Immortal Sailors Enabled
-UI_WAVEDEFENSE_STATUS_LEAVE,Leave,Leave
-UI_WAVEDEFENSE_STATUS_LEAVE_CONFIRM,Are you sure you want to leave the match?,Are you sure you want to leave the match?
-UI_FWC_PASS_2026,2026 FWC Championship Pass,2026 FWC Championship Pass
-UI_WAVEDEFENSE_CLEARREWARD_DAILYLIMIT,Daily reward: %d / %d claimed today,Daily reward: %d / %d claimed today
+UI_WAVEDEFENSE_LISTPLAYER_EMPTYSLOT,Empty Slot,空きスロット
+UI_WAVEDEFENSE_STATUS_PASSWORD,Room password: %s,ルームパスワード：%s
+UI_WAVEDEFENSE_STATUS_KICK,Kick,追い出す
+UI_WAVEDEFENSE_STATUS_KICKTITLE,Kick user,ユーザーを追い出す
+UI_WAVEDEFENSE_STATUS_KICKMSG,You are about to kick user %s. Do you want to continue?,ユーザー %s を追い出そうとしています。続行しますか？
+UI_WAVEDEFENSE_STATUS_INVITETITLE,Invite user,ユーザーを招待
+UI_WAVEDEFENSE_STATUS_INVITEINFO,Please put the player name you want to invite in your Wave Defense match.,ウェーブディフェンスのマッチに招待したいプレイヤー名を入力してください。
+UI_WAVEDEFENSE_STATUS_INVITEPLAYER,Player name,プレイヤー名
+UI_WAVEDEFENSE_JOIN_TITLE,Confirm Wave,ウェーブディフェンスの確認
+UI_WAVEDEFENSE_JOIN_MSG,%s invites you to join wave defense match. Accept the invitation?,%s があなたをウェーブディフェンスのマッチに招待しています。招待を受け入れますか？
+UI_WAVEDEFENSE_JOINMATCH_TITLE,Join Wave Defense Match,ウェーブディフェンスのマッチに参加
+UI_WAVEDEFENSE_JOINMATCH_MSG,You are about to join match %s. Confirm?,マッチ %s に参加しようとしています。よろしいですか？
+UI_WAVEDEFENSE_JOINMATCH_PWD,Password,パスワード
+UI_WAVEDEFENSE_RANKING,Ranking,ランキング
+UI_WAVEDEFENSE_MILESTONE_HEADER,Milestones,マイルストーン
+UI_WAVEDEFENSE_MILESTONE_DESC,Clear waves with your team and claim exclusive rewards!,チームでウェーブをクリアして、限定報酬を受け取ろう！
+UI_WAVEDEFENSE_MILESTONE,Clear %d total waves,合計 %d ウェーブをクリア
+UI_WAVEDEFENSE_RANKING_RANK,Rank,順位
+UI_WAVEDEFENSE_RANKING_ROOM,Room Name,ルーム名
+UI_WAVEDEFENSE_RANKING_WAVE,Max Wave,最高到達ウェーブ
+UI_WAVEDEFENSE_RANKING_KILLS,Total Kills,合計討伐数
+UI_WAVEDEFENSE_RANKING_DEFENDERS,Sailors,船員
+UI_WAVEDEFENSE_RANKING_TIME,Time,時間
+UI_WAVEDEFENSE_MILESTONE_CLAIM,Claim,もらう
+UI_WAVEDEFENSE_RANKING_DESC,Dominate the rankings with your team and secure your place at the top!,チームでランキングを制覇し、頂点の座を勝ち取ろう！
+UI_WAVEDEFENSE_RANKINGDETAILS_HDR,Match Details,マッチ詳細
+UI_WAVEDEFENSE_RANKINGDETAILS_ROOMNAME,Room Name,ルーム名
+UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_NAME,Player,プレイヤー
+UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_JOB,Job,職業
+UI_WAVEDEFENSE_RANKINGDETAILS_PLAYERS_KILLS,Kills,討伐数
+UI_WAVEDEFENSE_STATUS_RESPAWN,Respawn in %s,%s 後にリスポーン
+UI_PVPMATCH_RESPAWNNOW,Respawn now,今すぐリスポーン
+UI_WAVEDEFENSE_INVITATION_INVITE,Invite,招待
+UI_WAVEDEFENSE_INVITATION_CLOSE,Close,閉じる
+UI_WAVEDEFENSE_HDRDAILYMATCHES,Daily matches: %d/%d,本日のマッチ回数：%d/%d
+UI_WAVEDEFENSE_SKIPWAVE_CONFIRM,Skip the remaining wait and start the next wave now?,残りの待機時間をスキップして、次のウェーブをすぐに開始しますか？
+UI_WAVEDEFENSE_CLEARREWARD_MAXEDTODAY,Already claimed today. Resets tomorrow.,本日分は受け取り済みです。翌日にリセットされます。
+UI_WAVEDEFENSE_STATUS_IMMORTAL,Immortal Sailors Enabled,船員無敵モード：有効
+UI_WAVEDEFENSE_STATUS_LEAVE,Leave,退出
+UI_WAVEDEFENSE_STATUS_LEAVE_CONFIRM,Are you sure you want to leave the match?,本当にマッチから退出しますか？
+UI_FWC_PASS_2026,2026 FWC Championship Pass,2026 FWCチャンピオンシップパス
+UI_WAVEDEFENSE_CLEARREWARD_DAILYLIMIT,Daily reward: %d / %d claimed today,本日の報酬：%d / %d 受け取り済み

--- a/Japanese/WaveDefense.txt
+++ b/Japanese/WaveDefense.txt
@@ -1,17 +1,17 @@
-﻿#b#cff00ffffTHE LAST BEACON: MISSION MANILA#nc#nb
+﻿#b#cff00ffffザ・ラストビーコン：ミッション・マニラ#nc#nb
 
-#cffffffffThe shipwreck was only the beginning.#nc The wrecked guild ship’s magical power source is leaking unstable energy, acting as a #b#cffff0000cursed beacon#nc#nb in the deep. This surge of power has become a massive lure, attracting the most relentless monsters of the abyss.
+#cffffffff難破はほんの始まりに過ぎなかった。#nc 難破したギルド船の魔力源が不安定なエネルギーを漏らし続け、深海で#b#cffff0000呪われたビーコン#nc#nbと化している。この力の奔流は巨大な誘引装置となり、深淵に潜む最も執拗なモンスターたちを引き寄せている。
 
-#b[MISSION BRIEFING]#nb
-#cffffff00Eight elite agents#nc must team up to #b#cff00ff00protect the 20 terrified sailors#nc#nb until the very end. Fend off 20 relentless waves of enemies and prove your mettle.
+#b[ミッション概要]#nb
+#cffffff00精鋭エージェント8名#nc が力を合わせ、#b#cff00ff00怯える20名の船員を最後まで守り抜く#nc#nbのだ。20波にわたる容赦なき敵の猛攻を退け、その実力を証明せよ。
 
-#b[ENEMY TYPES]#nb
-#b#cffff0000Common#nc#nb enemies are standard attackers.
-#b#cffff0000Healthy#nc#nb enemies have high HP and resist physical damage.
-#b#cffff0000Fast#nc#nb enemies move quickly and resist magic damage.
-#b#cffff0000Explosive#nc#nb enemies detonate on death.
+#b[敵の種類]#nb
+#b#cffff0000コモン#nc#nb：標準的な攻撃を行う敵。
+#b#cffff0000ヘルシー#nc#nb：HPが高く、物理ダメージへの耐性を持つ敵。
+#b#cffff0000ファスト#nc#nb：素早く動き、魔法ダメージへの耐性を持つ敵。
+#b#cffff0000エクスプローシブ#nc#nb：死亡時に爆発する敵。
 
-#b"You are the final line of defense between the survivors and total annihilation. Every second counts, and every position is critical."#nb
+#b「お前たちが、生存者たちと全滅の間に立つ最後の防衛線だ。一秒一秒が勝負を分け、どの持ち場も重要になる。」#nb
 
-#b[THE CHALLENGE]#nb
-The team that demonstrates the #b#cffffffffmost perfect defense#nc#nb will receive the ultimate honor. Are you ready to turn this tragedy into a record of great victory with your companions?
+#b[試練]#nb
+#b#cffffffff最も完璧な防衛#nc#nbを見せたチームには、最高の栄誉が贈られる。仲間たちとともに、この悲劇を偉大な勝利の記録へと変える準備はできているか？


### PR DESCRIPTION
## Description
Translates the Japanese strings for the new Wave Defense ("The Last Beacon") game mode, which were present in the files but left untranslated (identical to the English source):

- `UI.csv`: 84 keys — Wave Defense match creation/join UI, in-match status, ranking, rewards, plus `UI_PVPMATCH_RESPAWNNOW` and `UI_FWC_PASS_2026`
- `Skills.csv`: `PROPSKILL_TXT_150642`/`150643` — Wave Defense Buff name and description
- `MoverMenus.csv`: `MMI_1118`/`1119` — mover menu entries for The Last Beacon
- `Controls.csv`: `PROPCTRL_TXT_000743` — First Aid Kit
- `WaveDefense.txt`: full translation of the mission briefing text, with all inline markup tokens (`#b`, `#nb`, `#nc`, `#cffxxxxxx`) preserved

Only translation columns/content were changed; no keys were added, removed, or reordered.

## Checklist
- [x] Confirmed all edited files are UTF-8 encoded
- [x] Did not add, remove, or reorder any translation entries
- [x] Only edited the translation text (translation and/or correction of existing entries)
- [x] Did not modify keys, structure, or formatting
- [x] Read and agree to the terms of CLA.md