### PR TITLE
Fix Japanese translations in ScenarioQuests.csv

### DIFF
--- a/Japanese/ScenarioQuests.csv
+++ b/Japanese/ScenarioQuests.csv
@@ -164,8 +164,8 @@ PROPQUEST_SCENARIO_INC_000482,Journal of an Adventurer (1),冒険者の日記（
 PROPQUEST_SCENARIO_INC_000483,"Hello Adventurer. Although you don't know me, I must ask a favor of you. I have found something… incredible. Bring it to the Mayor of Darkon right away.",そこの君！急で申し訳ないが、１つ頼まれてくれないか？ダーコン市長が依頼していた書物をやっと手に入れたんだが、オイラは店を空ける事ができないんだ。オイラの代わりに君がこの本を渡してくれないか？
 PROPQUEST_SCENARIO_INC_000484,"Thank you, I am in your debt.",おお！頼んだぞ！
 PROPQUEST_SCENARIO_INC_000485,You can not understand the implications of this quest… He needs this book!,ダメか…仕方ないな…そう…ダメなら…な…
-PROPQUEST_SCENARIO_INC_000486,"You seem to have something important to say, what is it?",あら、あなた。何か用かしら？
-PROPQUEST_SCENARIO_INC_000487,OH MY! I can't believe this! The diary of the adventurer Bartholomew Hunt…,あ！これは…さすがタンディね。いくら彼でも、今回ばかりはもっと時間がかかると思ってたのに…。あなた、持ってきてくれてありがと！
+PROPQUEST_SCENARIO_INC_000486,"You seem to have something important to say, what is it?",話がありそうだな。何か用か？
+PROPQUEST_SCENARIO_INC_000487,OH MY! I can't believe this! The diary of the adventurer Bartholomew Hunt…,なんてことだ！信じられない！冒険者バルソロミュー・ハントの日記じゃないか…
 PROPQUEST_SCENARIO_INC_000488,Deliver the Diary to the Mayor of Darkon.,ダーコン市長に頼まれていた本を手に入れたが、忙しくて動けない。代わりに書物を渡してください。
 PROPQUEST_SCENARIO_INC_000490,Journal of an Adventurer (2),ある冒険家の日記　2章
 PROPQUEST_SCENARIO_INC_000491,"You should hear this. This is the diary of the adventurer Bartholomew Hunt. My grand father knew of him, he was a legend at one time…",ちょっと聞いてくれ。実は、これはハーモニンという探検家が書いた日記なのだ。私の祖父が彼と友達で、幼い頃私にいつも冒険談を聞かせてくれたことを今でも覚えているよ。


### PR DESCRIPTION
I revised it because the content was inappropriate.

### Description
Briefly describe the changes made in this pull request.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
