### PR TITLE
[Japanese] Reword Lv60/80/165 GS menu labels in MoverMenus.csv

### DIFF
--- a/Japanese/MoverMenus.csv
+++ b/Japanese/MoverMenus.csv
@@ -82,20 +82,20 @@ MMI_1014,Exchange Dice,ダイスの交換
 MMI_1015,Pet Sacrificing,ペットサクリファイス
 MMI_1016,Red Chip Shop,レッドチップショップ
 MMI_1017,Cosmetic Wardrobe,コスメティックワードローブ
-MMI_1018,Lv80 GS Apply,Lv80 GS適用
-MMI_1019,Lv80 GS Status,Lv80 GSステータス
-MMI_1020,Lv80 GS Cancel,Lv80 GSキャンセル
-MMI_1021,Lv80 GS Enter,Lv80 GSジョイン
-MMI_1022,Lv80 GS Lineup Setup,Lv80 GSラインナップ
-MMI_1023,Lv80 GS Ranking,Lv80GSランキング
-MMI_1024,Lv80 GS Information,Lv80GS情報
-MMI_1025,Lv60 GS Apply,Lv60GS適用
-MMI_1026,Lv60 GS Status,Lv60 GSステータス
-MMI_1027,Lv60 GS Cancel,Lv60 GSキャンセル
-MMI_1028,Lv60 GS Enter,Lv60 GS ジョイン
-MMI_1029,Lv60 GS Lineup Setup,Lv60 GSラインナップ
-MMI_1030,Lv60 GS Ranking,Lv60GSランキング
-MMI_1031,Lv60 GS Information,Lv60GS情報
+MMI_1018,Lv80 GS Apply,Lv80 GS 申請
+MMI_1019,Lv80 GS Status,Lv80 GS 申請状況
+MMI_1020,Lv80 GS Cancel,Lv80 GS キャンセル
+MMI_1021,Lv80 GS Enter,Lv80 GS 入場
+MMI_1022,Lv80 GS Lineup Setup,Lv80 GS チーム編成
+MMI_1023,Lv80 GS Ranking,Lv80 GS ランキング
+MMI_1024,Lv80 GS Information,Lv80 GS 情報
+MMI_1025,Lv60 GS Apply,Lv60 GS 申請
+MMI_1026,Lv60 GS Status,Lv60 GS 申請状況
+MMI_1027,Lv60 GS Cancel,Lv60 GS キャンセル
+MMI_1028,Lv60 GS Enter,Lv60 GS 入場
+MMI_1029,Lv60 GS Lineup Setup,Lv60 GS チーム編成
+MMI_1030,Lv60 GS Ranking,Lv60 GS ランキング
+MMI_1031,Lv60 GS Information,Lv60 GS 情報
 MMI_1032,Blue Chip Shop,ブルーチップショップ
 MMI_1033,Valentine's Letter Exchange,バレンタインレター交換
 MMI_1034,Dungeon,ダンジョン
@@ -188,13 +188,13 @@ MMI_2032,PTS Exchange (New Equipment),PTS交換(新装備)
 MMI_2033,Item Exchange,アイテム交換
 MMI_1118,The Last Beacon,ザ・ラストビーコン
 MMI_1119,Re-join Last Beacon match,ザ・ラストビーコンのマッチに再参加
-MMI_1122,Lv165 GS Apply,Lv165 GS適用
-MMI_1123,Lv165 GS Status,Lv165 GSステータス
-MMI_1124,Lv165 GS Cancel,Lv165 GSキャンセル
-MMI_1125,Lv165 GS Join,Lv165 GSジョイン
-MMI_1126,Lv165 GS Line Up,Lv165 GSラインナップ
-MMI_1127,Lv165 GS Ranking,Lv165GSランキング
-MMI_1128,Lv165 GS Information,Lv165GS情報
+MMI_1122,Lv165 GS Apply,Lv165 GS 申請
+MMI_1123,Lv165 GS Status,Lv165 GS 申請状況
+MMI_1124,Lv165 GS Cancel,Lv165 GS キャンセル
+MMI_1125,Lv165 GS Join,Lv165 GS 入場
+MMI_1126,Lv165 GS Line Up,Lv165 GS チーム編成
+MMI_1127,Lv165 GS Ranking,Lv165 GS ランキング
+MMI_1128,Lv165 GS Information,Lv165 GS 情報
 MMI_1129,Yellow Chip Shop 2,イエローチップショップ2
 MMI_1130,Red Chip Shop 2,レッドチップショップ2
 MMI_1131,Kalgas Chip Shop 2,カルガスチップショップ2


### PR DESCRIPTION
### Description
Reworded the Japanese translations of the Lv60/80/165 Guild Siege menu button labels in `MoverMenus.csv` (`MMI_1018`-`MMI_1031`, `MMI_1122`-`MMI_1128`). The previous translations for Apply/Status/Enter(Join)/Lineup Setup were literal/katakana renderings ("適用"/"ステータス"/"ジョイン"/"ラインナップ") that read awkwardly as menu button labels. Reworded to 申請/申請状況/入場/チーム編成 for clarity, unified consistently across all three level tiers (Lv60/80/165). Only the translation column was changed; keys and English source text are untouched.

### 説明
`MoverMenus.csv` の Lv60/80/165 ギルドコンバット関連メニューボタン（`MMI_1018`〜`MMI_1031`、`MMI_1122`〜`MMI_1128`）の日本語訳を修正しました。従来の Apply/Status/Enter(Join)/Lineup Setup の訳は「適用」「ステータス」「ジョイン」「ラインナップ」という直訳・カタカナ表記で、メニューボタンのラベルとして分かりにくいものでした。「申請」「申請状況」「入場」「チーム編成」に修正し、Lv60/80/165の3階層すべてで表記を統一しました。変更したのは翻訳列のみで、キーと英語原文は変更していません。

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
  編集したすべてのファイルが UTF-8 でエンコードされていることを確認しました
- [x] I did not add, delete, or reorder any translation entries
  翻訳エントリの追加・削除・並び替えを行っていません
- [x] I only edited translation text (translation and/or correction of existing entries)
  翻訳テキストのみを編集しました（既存エントリの翻訳および/または修正）
- [x] I did not modify keys, structure, or formatting
  キー、構造、書式を変更していません
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
  **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** の条件を読み、同意しました。私の貢献が Gala Lab Corp. の独占的な財産となり、本プロジェクト外での再利用ができないことを理解しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)