### PR TITLE
[Japanese] Unify Soul-Linked/Soul-Bound/Account-Linked wording

### DIFF
--- a/Japanese/Items.csv
+++ b/Japanese/Items.csv
@@ -7586,8 +7586,8 @@ PROPITEM_TXT_100972,Beach Box A,ビーチボックスA
 PROPITEM_TXT_100973,Beach Box B,ビーチボックスB
 PROPITEM_TXT_100974,Superior Beach Box A,スーペリア ビーチ ボックス A
 PROPITEM_TXT_100975,Superior Beach Box B,スーペリア ビーチ ボックス B
-PROPITEM_TXT_100976,There is a chance to get a time-limited soul-linked Beachwear Costume Box.,期間限定の帰属ビーチウェア衣装ボックスを獲得するチャンスがあります。
-PROPITEM_TXT_100977,There is a chance to get a time-limited soul-linked Swimwear Costume Box.,期間限定の帰属水着コスチュームボックスが手に入るチャンスです。
+PROPITEM_TXT_100976,There is a chance to get a time-limited soul-linked Beachwear Costume Box.,期間限定のキャラ帰属のビーチウェア衣装ボックスを獲得するチャンスがあります。
+PROPITEM_TXT_100977,There is a chance to get a time-limited soul-linked Swimwear Costume Box.,期間限定のキャラ帰属の水着コスチュームボックスが手に入るチャンスです。
 PROPITEM_TXT_100978,There is a chance to get a Scroll of SProtect or a Beachwear Costume Box.,鍛冶屋の心得・精錬編またはビーチウェアコスチュームボックスを獲得できるチャンスがあります。
 PROPITEM_TXT_100979,There is a chance to get a Scroll of SProtect or a Swimwear Costume Box.,一定確率で鍛冶屋の心得・精錬編や水着ウェアコスチュームボックスを獲得できます。
 PROPITEM_TXT_100980,Baby Shark Costume Lucky Box,ベビーシャークコスチュームラッキーボックス
@@ -24838,11 +24838,11 @@ PROPITEM_TXT_155642,Select which Warrior Horse you want to receive!,受け取り
 PROPITEM_TXT_155643,Demian Server Welcome Coupon,Demianサーバーウェルカムクーポン
 PROPITEM_TXT_155644,"A package containing 5x [Event] Adventurer's Fortune Flask (3 Days), 12x Scroll of Amplification ES, 3x Activation, 10x Vital Drink X or Refresher Hold, 1x Extra Bag (30 days), 10x Blinkwing of Madrigal, 5x Def-Upcut Stone, 10x Scroll of Resurrection, 1x Madrigal Flying Selection Box (30 days), 1x Madrigal PickupPet Selection Box (30 days), 1x I am PANG! and 1x Aura Selection Box (15 days). All items are Soul-Linked.",[イベント]冒険者のフォーチュンフラスコ(3日)x5、戦神の巻物ESx12、アクティビションx3、スタミナドリンクXまたは魔力ドリンクゴールドx10、魔法の携帯バッグ(30日)x1、ブリンクウイング（マドリガル）x10、ディフェンスストーンx5、復活の巻物x10、マドリガルフライングセレクションボックス(30日)x1、マドリガルピックアップペットセレクションボックス(30日)x1、I am PANG!x1、オーラセレクションボックス(15日)x1が含まれたパッケージ。全てのアイテムはプレイヤーに帰属されています。
 PROPITEM_TXT_155645,FWC 2025 Shiny Bloody Tiger,FWC2025シャイニー・ブラッディータイガー
-PROPITEM_TXT_155646,[Soul-Linked] 2025 Mycard Promotion Box A,[魂の絆]2025 MyCardプロモーションボックスA
+PROPITEM_TXT_155646,[Soul-Linked] 2025 Mycard Promotion Box A,[キャラ帰属]2025 MyCardプロモーションボックスA
 PROPITEM_TXT_155647,"A package containing 3x Scroll of Amplification ES, 3x Upcut Stone, 7x Def-Upcut Stone and 3x Vital Drink X or Refresher Hold. All items are Soul-Linked.",戦神の巻物ESx3、パワーストーンx3、ディフェンスストーンx7、スタミナドリンクXまたは魔力ドリンクゴールドx3が含まれたパッケージ。全てのアイテムはプレイヤーに帰属されています。
-PROPITEM_TXT_155648,[Soul-Linked] 2025 Mycard Promotion Box B,[魂の絆]2025 MyCardプロモーションボックスB
+PROPITEM_TXT_155648,[Soul-Linked] 2025 Mycard Promotion Box B,[キャラ帰属]2025 MyCardプロモーションボックスB
 PROPITEM_TXT_155649,"A package containing 10x Grilled Eel, 3x Power Scroll, 10x Flask Box and 1x Blue Snowboarder Set. All items are Soul-Linked.",グリルド・イールx10、豪傑のスクロール(B)x3、秘薬ボックスx10、ブルースノーボーダーセットx1が含まれたパッケージ。全てのアイテムはプレイヤーに帰属されています。
-PROPITEM_TXT_155650,[Soul-Linked] 2025 Mycard Promotion Box C,[魂の絆]2025 MyCardプロモーションボックスC
+PROPITEM_TXT_155650,[Soul-Linked] 2025 Mycard Promotion Box C,[キャラ帰属]2025 MyCardプロモーションボックスC
 PROPITEM_TXT_155651,"A package containing 10x Scroll of Amplification ES, 10x Power Scroll, 10x Balloon Select Box(6h), 1x Extra Bag (30 days), 10x Scroll of SProtect and 1x Winter Casual 10% Black Set. All items are Soul-Linked.",戦神の巻物ESx10、豪傑のスクロール(B)x10、バルーンセレクトボックス(6時間)x10、魔法の携帯バッグ(30日)x1、鍛冶屋の心得・精錬編x10、ウィンターカジュアル10%ブラックセットx1が含まれたパッケージ。全てのアイテムはプレイヤーに帰属されています。
 PROPITEM_TXT_155652,Winter Costume Select Box 1,ウィンターコスチューム選択ボックス1
 PROPITEM_TXT_155653,Select which Winter Costume you want to receive!,受け取りたいウィンターコスチュームを選択してください！

--- a/Japanese/TextClient.csv
+++ b/Japanese/TextClient.csv
@@ -796,7 +796,7 @@ TEXTCLIENT_BOUNTYINPUT_WAIT,You must wait before registering a bounty on this pl
 TEXTCLIENT_BOUNTYPOS_OFFLINE,%s is currently offline.,%sは現在オフラインです。
 TEXTCLIENT_INVENTORYSPACE,Your inventory space increased by %d!,インベントリのスペースが%d増加しました！
 TEXTCLIENT_UPGRADEANNOUNCE,%s upgraded %s to %s+%d!,%s が %s を %s+%dに精錬成功！
-TEXTCLIENT_UPGRADEANNOUNCE_BOUND,%s upgraded [Soul-Bound] %s to %s+%d!,%s が[装備帰属] %s を %s+%dに精錬成功！
+TEXTCLIENT_UPGRADEANNOUNCE_BOUND,%s upgraded [Soul-Bound] %s to %s+%d!,%s が[キャラ帰属] %s を %s+%dに精錬成功！
 TEXTCLIENT_LEVELUPANNOUNCE,%s reached level %d!,%sがレベル%dに達しました！
 TEXTCLIENT_APP_GACHA,Gacha,ガチャ
 TEXTCLIENT_GACHA_RESET_SUCCESS,The box has been successfully reset.,ボックスは正常にリセットされました。

--- a/Japanese/UI.csv
+++ b/Japanese/UI.csv
@@ -1104,8 +1104,8 @@ UI_RESHUFFLECARD_TITLE,Weapon Socket Card Reroll,ウェポンソケットカー�
 UI_RESHUFFLECARD_REGISTER,Insert weapon cards to use as materials.,武器素材カードを登録します。
 UI_RESHUFFLECARD_INFO,Fuse 3 weapon cards to receive 1 card of the same grade.,武器素材のカードを3枚合体させると、同グレードのカードが1枚手に入ります。
 UI_RESHUFFLECARD_CONFIRM,Rerolling will consume the material cards. Proceed?,カードを入れ替えると、素材として使われていたカードは消えます。続行しますか?
-UI_CONVERTSOULLINK_TITLE,Convert to Soul-Linked,帰属を変換する
-UI_CONVERTSOULLINK_INFO,"The item will become soul-linked and can no longer be sold to NPCs. You can use this process to stack identical items that otherwise cannot be stacked due to differing properties. Note: Soul-linked items cannot be traded, and this action cannot be undone.",アイテムをソウルリンクタイプに変換できます。
+UI_CONVERTSOULLINK_TITLE,Convert to Soul-Linked,キャラ帰属に変換する
+UI_CONVERTSOULLINK_INFO,"The item will become soul-linked and can no longer be sold to NPCs. You can use this process to stack identical items that otherwise cannot be stacked due to differing properties. Note: Soul-linked items cannot be traded, and this action cannot be undone.",アイテムはキャラ帰属になり、NPCへの売却ができなくなります。プロパティの違いにより重ならないアイテムを重ねたい場合にこの処理を利用できます。注意：キャラ帰属アイテムは取引できず、この操作は元に戻せません。
 UI_CONVERTSOULLINK_CONFIRM,This action cannot be undone.\nProceed?,変換されたアイテムは返品できません。続行しますか?
 UI_CONVERTSOULLINK_NOTAVAILABLE,This item cannot be converted.,このアイテムは変換できません。
 UI_GUILD_SCROLLGADD_CONFIRM,This scroll permanently increases your guild's member limit by 5. It only applies to your current guild and will not affect any guild you join later. Use it now?,この巻物を使用すると、ギルドに所属できるメンバーが永久に5人分増加します。現在のギルドでのみ機能します。新たに他のギルドへ入った場合は、効果はありません。使用しますか？
@@ -1301,7 +1301,7 @@ UI_CHAT_TITLE,Chat,チャット
 UI_CHAT_FILTERS,Filters,フィルター
 UI_CHAT_VIEW_LANGUAGES,View Languages,言語を表示
 UI_CHAT_YOUR_LANGUAGE,Your Language,使用言語
-UI_INVENTORY_CONVERT_SOULLINK,Convert to Soul-Linked,帰属を変換する
+UI_INVENTORY_CONVERT_SOULLINK,Convert to Soul-Linked,キャラ帰属に変換する
 UI_INVENTORY_PUTCHAT,Link in Chat,チャットでリンク
 UI_INVENTORY_LOCK,Mark Favorite,お気に入りにする
 UI_INVENTORY_UNLOCK,Unmark Favorite,お気に入りを解除する
@@ -1404,7 +1404,7 @@ UI_TOOLTIP_ITEM_BINDING,Binding,関連
 UI_TOOLTIP_ITEM_BINDING_DESC,This material makes the target item Soul-Bound.,このアイテムは対象のアイテムを帰属(Soul-Bound)にします。
 UI_BINDING_NOTICE,#cffff0000This will bind the item to your character. You can undo this with a Scroll of Unbinding.#nc,#cffff0000この操作により、アイテムはあなたのキャラクターに帰属（バインド）されます。帰属解除の巻物で解除することができます。#nc
 UI_BINDING_MESSAGE,This item is now bound to your character.,このアイテムは、キャラクターに帰属されています。
-UI_TOOLTIP_ITEM_BOUND,[Soul-Bound],[装備帰属]
+UI_TOOLTIP_ITEM_BOUND,[Soul-Bound],[キャラ帰属]
 UI_TOOLTIP_ITEM_BOUND_DESC,Can be unbound.,帰属（バインド）を解除できます。
 UI_BINDING_TITLE,Binding,関連
 UI_BINDING_CONFIRM,Do you want to continue?,続けますか？
@@ -2143,8 +2143,8 @@ UI_UPGRADE_ULTIMATE_WEAPON_LVL3,Achieve Ultimate Upgrade +3,究極アップグ�
 UI_UPGRADE_ULTIMATE_WEAPON_LVL4,Achieve Ultimate Upgrade +4,究極アップグレード+4を達成した
 UI_UPGRADE_ULTIMATE_WEAPON_LVL5,Achieve Ultimate Upgrade +5,究極アップグレード+5を達成した
 UI_RAINBOWRACE_RANKING,Leaderboard,リーダーボード
-UI_EXCHANGE_ACCOUNTLINK,#cffff0000The result will be Account-Linked because some of the materials are Account-Linked.#nc,生け贄アイテムの一部がアカウントリンクされているため、#cffff0000You アカウントリンクアイテムを取得します #nc
-UI_EXCHANGE_SOULLINK,#cffff0000The result will be Soul-Linked because some of the materials are Soul-Linked.#nc,#cffff0000生け贄のアイテムの一部がキャラ帰属になっているため、完了後はキャラ帰属アイテムとなります。#nc
+UI_EXCHANGE_ACCOUNTLINK,#cffff0000The result will be Account-Linked because some of the materials are Account-Linked.#nc,#cffff0000交換アイテムの一部がアカウント帰属になっているため、完了後はアカウント帰属アイテムとなります。#nc
+UI_EXCHANGE_SOULLINK,#cffff0000The result will be Soul-Linked because some of the materials are Soul-Linked.#nc,#cffff0000交換アイテムの一部がキャラ帰属になっているため、完了後はキャラ帰属アイテムとなります。#nc
 UI_RAINBOWRACE_TELEPORT_TITLE,Rainbow Race,レインボーレース
 UI_RAINBOWRACE_TELEPORT_MSG,"The Rainbow Race will begin shortly. Teleport to the starting point? If you decline, you will be disqualified with no refund.",レインボーレースがまもなく始まります。スタート地点にテレポートしますか?辞退した場合、レースから失格となり、払い戻しは行われません。
 UI_BATTLEPASS_CHRISTMAS2023,Christmas Pass 2023,クリスマスパス 2023
@@ -2792,7 +2792,7 @@ UI_GENERALAWAKE_TITLEDEMONBLESSING,Blessing of the Demon,悪魔の祝福
 UI_TOOLTIP_FREEBLESSING,Demon Blessing,デーモンの祝福
 UI_CHARINFO_HOUSING_SLOTS,Pet Inventory Slots,ペットインベントリ枠
 UI_GENERALAWAKE_SOULBIND_TITLE,Use Blessing?,祝福を使用しますか？
-UI_GENERALAWAKE_SOULBIND,Applying a blessing will make the item soul-linked while the blessing is active. Proceed? Blessings of the Goddess can be removed by Jewel Manager NPCs.,祝福を付与すると、祝福が有効な間そのアイテムはソウルリンクされます。続行しますか？女神の祝福はジュエルマネージャーNPCで解除できます。
+UI_GENERALAWAKE_SOULBIND,Applying a blessing will make the item soul-linked while the blessing is active. Proceed? Blessings of the Goddess can be removed by Jewel Manager NPCs.,祝福を付与すると、祝福が有効な間そのアイテムはキャラ帰属になります。続行しますか？女神の祝福はジュエルマネージャーNPCで解除できます。
 UI_RECIPE_NOT_FULL,"The recipe is not fully understood, so only one of each ingredient is used.",レシピを完全に習得していないため、各素材が1つずつのみ使用されます。
 UI_CHRISTMAS_INVANSION_MISSION,Quest completed,クエスト完了
 UI_TELEPORT_ARENA,Exit the arena?,アリーナから退出しますか？


### PR DESCRIPTION
### Description
Soul-Linked, Soul-Bound, and Account-Linked item-binding terms were inconsistently translated across `Items.csv`, `UI.csv`, and `TextClient.csv` (mix of 帰属/装備帰属/魂の絆/ソウルリンク/アカウントリンク for the same concepts).

- `[Soul-Linked]` tag: 魂の絆 → キャラ帰属 (3 entries in `Items.csv`)
- `[Soul-Bound]` tag: 装備帰属 → キャラ帰属 (`TextClient.csv`, `UI.csv`)
- Remaining ソウルリンク transliterations (`UI_CONVERTSOULLINK_INFO`, `UI_GENERALAWAKE_SOULBIND`) → キャラ帰属; also restored a warning sentence ("Note: Soul-linked items cannot be traded, and this action cannot be undone.") that had been dropped entirely from `UI_CONVERTSOULLINK_INFO`
- Account-Linked: アカウントリンク → アカウント帰属 (`UI_EXCHANGE_ACCOUNTLINK`), matching the existing `UI_TOOLTIP_ACCOUNT_BINDS` wording
- `UI_EXCHANGE_ACCOUNTLINK` / `UI_EXCHANGE_SOULLINK`: 生け贄アイテム ("sacrifice item") → 交換アイテム, a more natural term for exchange/crafting materials
- Two costume box description lines (`PROPITEM_TXT_100976`/`100977`) reworded from an unnatural bare 帰属 prefix to キャラ帰属の〇〇
- `UI_CONVERTSOULLINK_TITLE` / `UI_INVENTORY_CONVERT_SOULLINK`: awkward 帰属を変換する ("convert the binding") → キャラ帰属に変換する ("convert to character-bound")

Only the translation column was changed; keys and English source text are untouched. Line counts verified to match `English_Reference`.

### 説明
「Soul-Linked」「Soul-Bound」「Account-Linked」（アイテムの帰属関連）の日本語表記が`Items.csv`・`UI.csv`・`TextClient.csv`内で「帰属」「装備帰属」「魂の絆」「ソウルリンク」「アカウントリンク」等に割れていました。

- `[Soul-Linked]`タグ：「魂の絆」→「キャラ帰属」（`Items.csv`3件）
- `[Soul-Bound]`タグ：「装備帰属」→「キャラ帰属」（`TextClient.csv`、`UI.csv`）
- 音訳「ソウルリンク」（`UI_CONVERTSOULLINK_INFO`、`UI_GENERALAWAKE_SOULBIND`）→「キャラ帰属」。あわせて`UI_CONVERTSOULLINK_INFO`で丸ごと欠落していた警告文（「注意：キャラ帰属アイテムは取引できず、この操作は元に戻せません。」）を追加翻訳
- Account-Linked：「アカウントリンク」→「アカウント帰属」（`UI_EXCHANGE_ACCOUNTLINK`）、既存の`UI_TOOLTIP_ACCOUNT_BINDS`表記に統一
- `UI_EXCHANGE_ACCOUNTLINK` / `UI_EXCHANGE_SOULLINK`：「生け贄アイテム」を、交換・生産素材として自然な「交換アイテム」に変更
- コスチュームボックスの説明文2件（`PROPITEM_TXT_100976`/`100977`）：不自然だった「帰属〇〇」を「キャラ帰属の〇〇」に修正
- `UI_CONVERTSOULLINK_TITLE` / `UI_INVENTORY_CONVERT_SOULLINK`：不自然だった「帰属を変換する」を「キャラ帰属に変換する」に修正

変更したのは翻訳列のみで、キーと英語原文は変更していません。`English_Reference`との行数一致を確認済みです。

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
  編集したすべてのファイルが UTF-8 でエンコードされていることを確認しました
- [x] I did not add, delete, or reorder any translation entries
  翻訳エントリの追加・削除・並び替えを行っていません
- [x] I only edited translation text (translation and/or correction of existing entries)
  翻訳テキストのみを編集しました（既存エントリの翻訳および/または修正）
- [x] I did not modify keys, structure, or formatting
  キー、構造、書式を変更していません
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
  **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** の条件を読み、同意しました。私の貢献が Gala Lab Corp. の独占的な財産となり、本プロジェクト外での再利用ができないことを理解しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)