### PR TITLE
[Japanese] Unify Demon Blessing wording to 悪魔の祝福 in UI.csv

### DIFF
--- a/Japanese/UI.csv
+++ b/Japanese/UI.csv
@@ -2789,7 +2789,7 @@ UI_PRIVATE_SHOP_ADSOPEN,Your Shop Advertisement item will be consumed.,ショッ
 UI_PRIVATE_SHOP_ADSCLOSE,Your Shop Advertisement item cannot be reused.,ショップ広告アイテムは再利用できません。
 UI_GENERALAWAKE_TITLEGODDESSBLESSING,Blessing of the Goddess,女神の祝福
 UI_GENERALAWAKE_TITLEDEMONBLESSING,Blessing of the Demon,悪魔の祝福
-UI_TOOLTIP_FREEBLESSING,Demon Blessing,デーモンの祝福
+UI_TOOLTIP_FREEBLESSING,Demon Blessing,悪魔の祝福
 UI_CHARINFO_HOUSING_SLOTS,Pet Inventory Slots,ペットインベントリ枠
 UI_GENERALAWAKE_SOULBIND_TITLE,Use Blessing?,祝福を使用しますか？
 UI_GENERALAWAKE_SOULBIND,Applying a blessing will make the item soul-linked while the blessing is active. Proceed? Blessings of the Goddess can be removed by Jewel Manager NPCs.,祝福を付与すると、祝福が有効な間そのアイテムはソウルリンクされます。続行しますか？女神の祝福はジュエルマネージャーNPCで解除できます。


### PR DESCRIPTION
### Description
`UI_TOOLTIP_FREEBLESSING` ("Demon Blessing") was translated as デーモンの祝福 (transliteration), while `UI_GENERALAWAKE_TITLEDEMONBLESSING` ("Blessing of the Demon") and other related entries (`TEXTCLIENT_BLESSING_NOREMOVEFREE`, `Items.csv` package descriptions, etc.) consistently use 悪魔の祝福. Aligned `UI_TOOLTIP_FREEBLESSING` to 悪魔の祝福. Only the translation column was changed; keys and English source text are untouched.

### 説明
`UI_TOOLTIP_FREEBLESSING`（"Demon Blessing"）が音訳「デーモンの祝福」と訳されていましたが、`UI_GENERALAWAKE_TITLEDEMONBLESSING`（"Blessing of the Demon"）や他の関連箇所（`TEXTCLIENT_BLESSING_NOREMOVEFREE`、`Items.csv`のパッケージ説明文等）では一貫して「悪魔の祝福」が使われていました。`UI_TOOLTIP_FREEBLESSING`を「悪魔の祝福」に統一しました。変更したのは翻訳列のみで、キーと英語原文は変更していません。

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
  編集したすべてのファイルが UTF-8 でエンコードされていることを確認しました
- [x] I did not add, delete, or reorder any translation entries
  翻訳エントリの追加・削除・並び替えを行っていません
- [x] I only edited translation text (translation and/or correction of existing entries)
  翻訳テキストのみを編集しました（既存エントリの翻訳および/または修正）
- [x] I did not modify keys, structure, or formatting
  キー、構造、書式を変更していません
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
  **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** の条件を読み、同意しました。私の貢献が Gala Lab Corp. の独占的な財産となり、本プロジェクト外での再利用ができないことを理解しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)