### PR TITLE
German - Use same spelling for all Lusaka Weapons

### DIFF
--- a/German/Items.csv
+++ b/German/Items.csv
@@ -12171,24 +12171,24 @@ PROPITEM_TXT_222145,Expands the bank space limit by 24 items for current charact
 PROPITEM_TXT_222146,Bank Extra Bag,Bank Extra Bag
 PROPITEM_TXT_222147,Expands the bank space limit by 24 items for current character. You can only use 1 at the same time.,Erweitert das Bankplatzlimit um 24 Gegenstände für den aktuellen Charakter. Du kannst nur jeweils einen Gegenstand gleichzeitig benutzen.
 PROPITEM_TXT_011432,Lusaka's Sword,Lusaka's Sword
-PROPITEM_TXT_011434,Lusaka's Axe,Luzaka's Axe
+PROPITEM_TXT_011434,Lusaka's Axe,Lusaka's Axe
 PROPITEM_TXT_011436,Lusaka's Heavy Sword,Lusaka's Heavy Sword
 PROPITEM_TXT_011438,Lusaka's Heavy Axe,Lusaka's Heavy Axe
 PROPITEM_TXT_011440,Lusaka's Fist,Lusaka's Fist
-PROPITEM_TXT_011442,Lusaka's Stick,Luzaka's Stick
-PROPITEM_TXT_011444,Lusaka's Wand,Luzaka's Wand
-PROPITEM_TXT_011446,Lusaka's Staff,Luzaka's Staff
-PROPITEM_TXT_011448,Lusaka's Bow,Luzaka's Bow
+PROPITEM_TXT_011442,Lusaka's Stick,Lusaka's Stick
+PROPITEM_TXT_011444,Lusaka's Wand,Lusaka's Wand
+PROPITEM_TXT_011446,Lusaka's Staff,Lusaka's Staff
+PROPITEM_TXT_011448,Lusaka's Bow,Lusaka's Bow
 PROPITEM_TXT_011450,Lusaka's Yo-Yo,Lusaka's Yo-Yo
-PROPITEM_TXT_011452,Lusaka's Crystal Sword,Luzaka's Crystal Sword
-PROPITEM_TXT_011454,Lusaka's Crystal Axe,Luzaka's Crystal Axe
+PROPITEM_TXT_011452,Lusaka's Crystal Sword,Lusaka's Crystal Sword
+PROPITEM_TXT_011454,Lusaka's Crystal Axe,Lusaka's Crystal Axe
 PROPITEM_TXT_011456,Lusaka's Heavy Crystal Sword,Lusaka's Heavy Crystal Sword
 PROPITEM_TXT_011458,Lusaka's Heavy Crystal Axe,Lusaka's Heavy Crystal Axe
 PROPITEM_TXT_011460,Lusaka's Crystal Fist,Lusaka's Crystal Fist
-PROPITEM_TXT_011462,Lusaka's Crystal Stick,Luzaka's Crystal Stick
-PROPITEM_TXT_011464,Lusaka's Crystal Wand,Luzaka's Crystal Wand
-PROPITEM_TXT_011466,Lusaka's Crystal Staff,Luzaka's Crystal Staff
-PROPITEM_TXT_011468,Lusaka's Crystal Bow,Luzaka's Crystal Bow
+PROPITEM_TXT_011462,Lusaka's Crystal Stick,Lusaka's Crystal Stick
+PROPITEM_TXT_011464,Lusaka's Crystal Wand,Lusaka's Crystal Wand
+PROPITEM_TXT_011466,Lusaka's Crystal Staff,Lusaka's Crystal Staff
+PROPITEM_TXT_011468,Lusaka's Crystal Bow,Lusaka's Crystal Bow
 PROPITEM_TXT_011470,Lusaka's Crystal Yo-Yo,Lusaka's Crystal Yo-Yo
 PROPITEM_TXT_011471,An exquisitely crafted weapon found in The Wilds. It hums with power.,"Eine exquisit gefertigte Waffe, die in der Wildnis gefunden wurde. Sie vibriert vor Kraft."
 PROPITEM_TXT_014606,Coral Cutlass,Sword of Hernes


### PR DESCRIPTION
### Description
A player noticed that some weapons are called "LuZaka" and some "LuSaka" like english original. Thats annoying during shop search.
In german you pronounce it "LuSaka" so the Z doesnt make much sense at all. So we decided to change it to the english original to be in line with other rare weapons that are kept in english. 
(Only exception are Coral Weapons currently)

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
