### PR TITLE
- Added Japanese translations for quests in the Deadwallderness distr…

### DIFF
--- a/Japanese/RequestBoxQuests.csv
+++ b/Japanese/RequestBoxQuests.csv
@@ -147,7 +147,7 @@ PROPQUEST_REQUESTBOX_INC_000497,An Acrobat master needs you to gather Renyken to
 PROPQUEST_REQUESTBOX_INC_000502,An Acrobat master wants Renyken.,アクロバットマスターたちが、新しい武器を作るため、レ二キン55個の収集を依頼した。
 PROPQUEST_REQUESTBOX_INC_000507,Disguise of a Native,身を守る知恵
 PROPQUEST_REQUESTBOX_INC_000508,Darkon natives need you to collect Tangkask. Will you help?,ダーコンに住む人々が、モンスターの危険から身を守るため、タンマスクをかぶって外出するのが流行っているそうです。そこでタンマスク55個の収集を依頼されました。依頼を受けますか？
-PROPQUEST_REQUESTBOX_INC_000513,Darkon natives want Tankask.,ダーコンの住民たちが、モンスターの危険から抜けるため、タンカスクの収集を依頼した。
+PROPQUEST_REQUESTBOX_INC_000513,Darkon natives want Tankask.,ダーコンの住民たちが、モンスターの危険から身を守るため、タンマスクの収集を依頼した。
 PROPQUEST_REQUESTBOX_INC_000518,Woodworking Material,森林保護
 PROPQUEST_REQUESTBOX_INC_000529,The Best Shield,どんな槍も通さない盾
 PROPQUEST_REQUESTBOX_INC_000530,Remina needs Luchest to make the strongest shield in the world. Will you help?,ロッキーが、世界で一番強力な盾の製作に兆戦するそうです。そこで、材料となるラチェスト60個の依頼が来ました。依頼を受けますか？
@@ -159,23 +159,23 @@ PROPQUEST_REQUESTBOX_INC_000552,Lucky needs Hammamer to make a lucky hammer. Wil
 PROPQUEST_REQUESTBOX_INC_000557,Lucky wants Hammamer.,ロッキーが自分の作業道具を全て新しく作るため、ハンマハンマー60個の収集を依頼した。
 PROPQUEST_REQUESTBOX_INC_000562,Strange Collector (6),謎のコレクター・第六の依頼
 PROPQUEST_REQUESTBOX_INC_000573,Request of Lurif,ルリフのお願い
-PROPQUEST_REQUESTBOX_INC_000574,Could you do me a favor? I need Phanbubble. Can you help me please?,私のお願いを聞いてください。 ファンブブルが100個必要なのです。何に使うかって？　…それを聞かずに、黙って依頼を受けていただけませんか？　もちろん報酬は払います
-PROPQUEST_REQUESTBOX_INC_000579,Lurif needs many Phanbubbles.,理由は知らないが、ルリフが ファンブブルの収集を依頼した。その数100個。結構多いなあ。
-PROPQUEST_REQUESTBOX_INC_000815,Mysterious Magic Material,ドンフックを集めて！
-PROPQUEST_REQUESTBOX_INC_000816,Magician Master requested you to collect Merahook which is a magic material. Will you accept this request?,･･･何も理由は聞かないでくださいです。私のためにドンフックを集めてきてもらえますか？
-PROPQUEST_REQUESTBOX_INC_000817,You can collect them from the group of Chimeradon in the Deadwallderness.,キメラドン族が持っているのですよ。よろしくおねがいしますです。
-PROPQUEST_REQUESTBOX_INC_000826,Avenge Nerky,ハニーメインを集めて！
-PROPQUEST_REQUESTBOX_INC_000827,Krinton's pet Bearnerky got killed by the other Bearnerky. Krinton requested you to collect NerkyMane for revenge. Will you accept this request?,･･･何も理由は聞かないでくださいです。私のためにハニーメインを集めてきてもらえますか？
-PROPQUEST_REQUESTBOX_INC_000828,You can collect them from the group of Bearnerky in the Deadwallderness.,ハニーシーカー族が持っているのですよ。よろしくおねがいしますです。
-PROPQUEST_REQUESTBOX_INC_000837,Bolpor's favor,リンクルイットを集めて！
-PROPQUEST_REQUESTBOX_INC_000838,Bolpor requested you to collect Rincruet for making some special food. Will you accept this request?,･･･何も理由は聞かないでくださいです。私のためにリンクルイットを集めてきてもらえますか？
-PROPQUEST_REQUESTBOX_INC_000839,You can collect them from the group of Muffrin in the Deadwallderness.,マフリン・シェフらが持っているのですよ。よろしくおねがいしますです。
-PROPQUEST_REQUESTBOX_INC_000848,Toy Materials,ハーレーシフトを集めて！
-PROPQUEST_REQUESTBOX_INC_000849,A toy merchant requested you to collect Popshift for making fancy toys. Will you accept this request?,･･･何も理由は聞かないでくださいです。私のためにハーレーシフトを集めてきてもらえますか？
-PROPQUEST_REQUESTBOX_INC_000850,You can collect them from the group of Popcrank in the Deadwallderness.,ポップクランク族が持っているのですよ。よろしくおねがいしますです。
-PROPQUEST_REQUESTBOX_INC_000859,Evil Eyed Red Dragon,ドラゴンの牙を集めて！
-PROPQUEST_REQUESTBOX_INC_000860,Can you please go find Dragon Tooth of the Meteonyker Dragon for me? The Arena Manager Lay requested 5 of them.,･･･何も理由は聞かないでくださいです。私のためにドラゴンの牙を集めてきてもらえますか？
-PROPQUEST_REQUESTBOX_INC_000861,"You can collect them from Meteonyker. I heard it's in Dekane Dungeon. Be careful, the Meteonyker is very strong! It's  best if you go with a party!",メテオニカが持っています。よろしくおねがいしますです。
+PROPQUEST_REQUESTBOX_INC_000574,Could you do me a favor? I need Phanbubble. Can you help me please?,私のお願いを聞いてください。どうしてもファンブブルが必要なのです。何に使うかって？　…それを聞かずに、黙って依頼を受けていただけませんか？　もちろん報酬は払います。
+PROPQUEST_REQUESTBOX_INC_000579,Lurif needs many Phanbubbles.,詳しい理由は分からないが、ルリフがファンブブル60個の収集を依頼した。
+PROPQUEST_REQUESTBOX_INC_000815,Mysterious Magic Material,謎めいた魔法の素材
+PROPQUEST_REQUESTBOX_INC_000816,Magician Master requested you to collect Merahook which is a magic material. Will you accept this request?,とあるマジシャンマスターから、魔法の素材になるドンフックを集めてほしいと依頼されました。この依頼を受けますか？
+PROPQUEST_REQUESTBOX_INC_000817,You can collect them from the group of Chimeradon in the Deadwallderness.,デッドウィルダニス砂漠に生息するアバドンの群れより、ドンフック60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000826,Avenge Nerky,ペットの仇を討て
+PROPQUEST_REQUESTBOX_INC_000827,Krinton's pet Bearnerky got killed by the other Bearnerky. Krinton requested you to collect NerkyMane for revenge. Will you accept this request?,シールドショップのクリントンが飼っていたペットが、ハニーシーカーに襲われて亡くなったそうです…。彼は復讐のために、ハニーメインを集めてほしいと依頼してきました。この依頼を受けますか？
+PROPQUEST_REQUESTBOX_INC_000828,You can collect them from the group of Bearnerky in the Deadwallderness.,デッドウィルダニス砂漠に生息するハニーシーカーの群れより、ハニーメイン60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000837,Bolpor's favor,料理人の好む食材
+PROPQUEST_REQUESTBOX_INC_000838,Bolpor requested you to collect Rincruet for making some special food. Will you accept this request?,フードショップのボルポーが、特別な料理を作るために必要なリンクルイットを集めてほしいと依頼してきました。この依頼を受けますか？
+PROPQUEST_REQUESTBOX_INC_000839,You can collect them from the group of Muffrin in the Deadwallderness.,デッドウィルダニス砂漠に生息するマフリン・シェフの群れより、リンクルイット60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000848,Toy Materials,おもちゃの素材
+PROPQUEST_REQUESTBOX_INC_000849,A toy merchant requested you to collect Popshift for making fancy toys. Will you accept this request?,とあるおもちゃショップから、かわいいおもちゃの装飾に必要なハーレーシフトを集めてほしいと依頼がありました。この依頼を引き受けますか？
+PROPQUEST_REQUESTBOX_INC_000850,You can collect them from the group of Popcrank in the Deadwallderness.,デッドウィルダニス砂漠に生息するポップクランクの群れより、ハーレーシフト60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000859,Evil Eyed Red Dragon,邪悪な眼をしたドラゴン
+PROPQUEST_REQUESTBOX_INC_000860,Can you please go find Dragon Tooth of the Meteonyker Dragon for me? The Arena Manager Lay requested 5 of them.,アリーナ管理者レイより、デェカネス鉱山奥地に生息するメテオニカを討伐してほしいと依頼がありました。ドラゴンの牙を5個集めてほしいそうです。とても邪悪なドラゴンなので、パーティーで向かうことをおすすめしますが…この依頼を受けますか？
+PROPQUEST_REQUESTBOX_INC_000861,"You can collect them from Meteonyker. I heard it's in Dekane Dungeon. Be careful, the Meteonyker is very strong! It's  best if you go with a party!",デェカネス鉱山の奥地に生息するメテオニカを倒し、ドラゴンの牙5個を入手する。
 PROPQUEST_REQUESTBOX_INC_010000,Moth Infestation,蛾の発生
 PROPQUEST_REQUESTBOX_INC_010001,Tina asked for help with reducing the Mothbee population as they're causing problems with transport. Could you kill 15 of them?,ティナから、輸送経路に＜モスビー＞が大量発生して問題になっているので、数を減らしてほしいという依頼がありました。15体ほど討伐してきていただけませんか？
 PROPQUEST_REQUESTBOX_INC_010002,You can find Mothbee flying inbetween Northern Saint City & Flaris.,モスビーは、セイントモーニング北部とフラリス間の上空に出現しています。
@@ -232,22 +232,22 @@ PROPQUEST_REQUESTBOX_INC_010052,"You can find the $QUEST_END_KILL_NAME$ flying W
 PROPQUEST_REQUESTBOX_INC_010053,Zenma Hunting (2),ゼンマー ハンティング (2)
 PROPQUEST_REQUESTBOX_INC_010054,Almani asked for further help regarding the Zenma threat. Could you get rid of the Lord Zenma?,アルマーニがゼンマーの脅威についてさらなる助けを求めています。ロード・ゼンマーを退治してもらえますか？
 PROPQUEST_REQUESTBOX_INC_010055,You can find the Lord Zenma flying above Gouthan Mountains.,ロード・ゼンマーは、ゴウダン山脈の上空を飛び回っています。
-PROPQUEST_REQUESTBOX_INC_020000,You can get $QUEST_END_ITEM_NAME$ from any type of Chimeradon.,$QUEST_END_ITEM_NAME$は、どのキメラドンからでも獲得できます。
-PROPQUEST_REQUESTBOX_INC_020001,You can get $QUEST_END_ITEM_NAME$ from any type of Bearnerky.,$QUEST_END_ITEM_NAME$は、どのハニーシーカーからでも獲得できます。
-PROPQUEST_REQUESTBOX_INC_020002,You can get $QUEST_END_ITEM_NAME$ from any type of Muffrin.,$QUEST_END_ITEM_NAME$ をマフリン・シェフたちから集める。
-PROPQUEST_REQUESTBOX_INC_020003,You can get $QUEST_END_ITEM_NAME$ from any type of Popcrank.,$QUEST_END_ITEM_NAME$ をポップクランクたちから集める。
-PROPQUEST_REQUESTBOX_INC_020004,You can collect $QUEST_END_ITEM_NAME$ from all types of Red Mantis.,$QUEST_END_ITEM_NAME$は、どのレッドマンティスからでも獲得できます。
+PROPQUEST_REQUESTBOX_INC_020000,You can get $QUEST_END_ITEM_NAME$ from any type of Chimeradon.,$QUEST_END_ITEM_NAME$は、どの種類のアバドンからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020001,You can get $QUEST_END_ITEM_NAME$ from any type of Bearnerky.,$QUEST_END_ITEM_NAME$は、どの種類のハニーシーカーからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020002,You can get $QUEST_END_ITEM_NAME$ from any type of Muffrin.,$QUEST_END_ITEM_NAME$は、どの種類のマフリン・シェフからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020003,You can get $QUEST_END_ITEM_NAME$ from any type of Popcrank.,$QUEST_END_ITEM_NAME$は、どの種類のポップクランクからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020004,You can collect $QUEST_END_ITEM_NAME$ from all types of Red Mantis.,$QUEST_END_ITEM_NAME$は、どの種類のレッドマンティスからでも入手できます。
 PROPQUEST_REQUESTBOX_INC_020005,Obsessed with Crystals! (1),クリスタルに夢中！(1)
 PROPQUEST_REQUESTBOX_INC_020006,Obsessed with Crystals! (2),クリスタルに夢中！(2)
 PROPQUEST_REQUESTBOX_INC_020007,Obsessed with Crystals! (3),クリスタルに夢中！(3)
 PROPQUEST_REQUESTBOX_INC_020008,Obsessed with Crystals! (4),クリスタルに夢中！(4)
 PROPQUEST_REQUESTBOX_INC_020009,Obsessed with Crystals! (5),クリスタルに夢中！(5)
 PROPQUEST_REQUESTBOX_INC_020010,Crystals! Hmmm.... $QUEST_END_ITEM_NAME$s! Could you please bring me some $QUEST_END_ITEM_NAME$!?,クリスタル!! うーん... $QUEST_END_ITEM_NAME$! $QUEST_END_ITEM_NAME$を持ってきてくれませんか!?
-PROPQUEST_REQUESTBOX_INC_020011,You can get $QUEST_END_ITEM_NAME$ from any type of Medumet.,どの種類のメデュメットからでも $QUEST_END_ITEM_NAME$ を入手できます。
-PROPQUEST_REQUESTBOX_INC_020012,You can get $QUEST_END_ITEM_NAME$ from any type of Yetti.,どのタイプのイエティからでも $QUEST_END_ITEM_NAME$ を入手できます。
-PROPQUEST_REQUESTBOX_INC_020013,You can get $QUEST_END_ITEM_NAME$ from any type of Augu.,$QUEST_END_ITEM_NAME$ は、どのタイプのアウグからでも入手できます。
-PROPQUEST_REQUESTBOX_INC_020014,You can get $QUEST_END_ITEM_NAME$ from any type of Ghost of the Forgotten.,$QUEST_END_ITEM_NAME$ は、どのタイプのゴーストからでも入手できます。
-PROPQUEST_REQUESTBOX_INC_020015,You can get $QUEST_END_ITEM_NAME$ from any type of Mammoth.,どの種類のマンモスからでも $QUEST_END_ITEM_NAME$ を入手できます。
+PROPQUEST_REQUESTBOX_INC_020011,You can get $QUEST_END_ITEM_NAME$ from any type of Medumet.,$QUEST_END_ITEM_NAME$は、どの種類のメデュメットからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020012,You can get $QUEST_END_ITEM_NAME$ from any type of Yetti.,$QUEST_END_ITEM_NAME$は、どの種類のイエティからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020013,You can get $QUEST_END_ITEM_NAME$ from any type of Augu.,$QUEST_END_ITEM_NAME$ は、どの種類のアウグからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020014,You can get $QUEST_END_ITEM_NAME$ from any type of Ghost of the Forgotten.,$QUEST_END_ITEM_NAME$ は、どの種類のゴーストからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020015,You can get $QUEST_END_ITEM_NAME$ from any type of Mammoth.,$QUEST_END_ITEM_NAME$は、どの種類のマンモスからでも入手できます。
 PROPQUEST_REQUESTBOX_INC_020016,You did it! Hooray! Here's your reward. Come back soon!,やったね！やったね！これはほんのお礼！また来てね！
 PROPQUEST_REQUESTBOX_INC_020017,More! More!,もっと！もっと！
 PROPQUEST_REQUESTBOX_INC_020018,Bring Broken Wings,折れた翼を持ってこい

--- a/Japanese/RequestBoxQuests.csv
+++ b/Japanese/RequestBoxQuests.csv
@@ -163,18 +163,18 @@ PROPQUEST_REQUESTBOX_INC_000574,Could you do me a favor? I need Phanbubble. Can 
 PROPQUEST_REQUESTBOX_INC_000579,Lurif needs many Phanbubbles.,詳しい理由は分からないが、ルリフがファンブブル60個の収集を依頼した。
 PROPQUEST_REQUESTBOX_INC_000815,Mysterious Magic Material,謎めいた魔法の素材
 PROPQUEST_REQUESTBOX_INC_000816,Magician Master requested you to collect Merahook which is a magic material. Will you accept this request?,とあるマジシャンマスターから、魔法の素材になるドンフックを集めてほしいと依頼されました。この依頼を受けますか？
-PROPQUEST_REQUESTBOX_INC_000817,You can collect them from the group of Chimeradon in the Deadwallderness.,デッドウィルダニス砂漠に生息するアバドンの群れより、ドンフック60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000817,You can collect them from the group of Chimeradon in the Deadwallderness.,デッドウィルダニス砂漠に生息するアバドンの群れから、ドンフック60個を入手する。
 PROPQUEST_REQUESTBOX_INC_000826,Avenge Nerky,ペットの仇を討て
 PROPQUEST_REQUESTBOX_INC_000827,Krinton's pet Bearnerky got killed by the other Bearnerky. Krinton requested you to collect NerkyMane for revenge. Will you accept this request?,シールドショップのクリントンが飼っていたペットが、ハニーシーカーに襲われて亡くなったそうです…。彼は復讐のために、ハニーメインを集めてほしいと依頼してきました。この依頼を受けますか？
-PROPQUEST_REQUESTBOX_INC_000828,You can collect them from the group of Bearnerky in the Deadwallderness.,デッドウィルダニス砂漠に生息するハニーシーカーの群れより、ハニーメイン60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000828,You can collect them from the group of Bearnerky in the Deadwallderness.,デッドウィルダニス砂漠に生息するハニーシーカーの群れから、ハニーメイン60個を入手する。
 PROPQUEST_REQUESTBOX_INC_000837,Bolpor's favor,料理人の好む食材
 PROPQUEST_REQUESTBOX_INC_000838,Bolpor requested you to collect Rincruet for making some special food. Will you accept this request?,フードショップのボルポーが、特別な料理を作るために必要なリンクルイットを集めてほしいと依頼してきました。この依頼を受けますか？
-PROPQUEST_REQUESTBOX_INC_000839,You can collect them from the group of Muffrin in the Deadwallderness.,デッドウィルダニス砂漠に生息するマフリン・シェフの群れより、リンクルイット60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000839,You can collect them from the group of Muffrin in the Deadwallderness.,デッドウィルダニス砂漠に生息するマフリン・シェフの群れから、リンクルイット60個を入手する。
 PROPQUEST_REQUESTBOX_INC_000848,Toy Materials,おもちゃの素材
 PROPQUEST_REQUESTBOX_INC_000849,A toy merchant requested you to collect Popshift for making fancy toys. Will you accept this request?,とあるおもちゃショップから、かわいいおもちゃの装飾に必要なハーレーシフトを集めてほしいと依頼がありました。この依頼を引き受けますか？
-PROPQUEST_REQUESTBOX_INC_000850,You can collect them from the group of Popcrank in the Deadwallderness.,デッドウィルダニス砂漠に生息するポップクランクの群れより、ハーレーシフト60個を入手する。
+PROPQUEST_REQUESTBOX_INC_000850,You can collect them from the group of Popcrank in the Deadwallderness.,デッドウィルダニス砂漠に生息するポップクランクの群れから、ハーレーシフト60個を入手する。
 PROPQUEST_REQUESTBOX_INC_000859,Evil Eyed Red Dragon,邪悪な眼をしたドラゴン
-PROPQUEST_REQUESTBOX_INC_000860,Can you please go find Dragon Tooth of the Meteonyker Dragon for me? The Arena Manager Lay requested 5 of them.,アリーナ管理者レイより、デェカネス鉱山奥地に生息するメテオニカを討伐してほしいと依頼がありました。ドラゴンの牙を5個集めてほしいそうです。とても邪悪なドラゴンなので、パーティーで向かうことをおすすめしますが…この依頼を受けますか？
+PROPQUEST_REQUESTBOX_INC_000860,Can you please go find Dragon Tooth of the Meteonyker Dragon for me? The Arena Manager Lay requested 5 of them.,アリーナ管理者レイより、デェカネス鉱山奥地に生息するメテオニカを討伐してほしいと依頼がありました。ドラゴンの牙を5個集めてほしいそうです。とても凶暴なドラゴンなので、パーティーで向かうことをおすすめしますが…この依頼を受けますか？
 PROPQUEST_REQUESTBOX_INC_000861,"You can collect them from Meteonyker. I heard it's in Dekane Dungeon. Be careful, the Meteonyker is very strong! It's  best if you go with a party!",デェカネス鉱山の奥地に生息するメテオニカを倒し、ドラゴンの牙5個を入手する。
 PROPQUEST_REQUESTBOX_INC_010000,Moth Infestation,蛾の発生
 PROPQUEST_REQUESTBOX_INC_010001,Tina asked for help with reducing the Mothbee population as they're causing problems with transport. Could you kill 15 of them?,ティナから、輸送経路に＜モスビー＞が大量発生して問題になっているので、数を減らしてほしいという依頼がありました。15体ほど討伐してきていただけませんか？
@@ -245,8 +245,8 @@ PROPQUEST_REQUESTBOX_INC_020009,Obsessed with Crystals! (5),クリスタルに�
 PROPQUEST_REQUESTBOX_INC_020010,Crystals! Hmmm.... $QUEST_END_ITEM_NAME$s! Could you please bring me some $QUEST_END_ITEM_NAME$!?,クリスタル!! うーん... $QUEST_END_ITEM_NAME$! $QUEST_END_ITEM_NAME$を持ってきてくれませんか!?
 PROPQUEST_REQUESTBOX_INC_020011,You can get $QUEST_END_ITEM_NAME$ from any type of Medumet.,$QUEST_END_ITEM_NAME$は、どの種類のメデュメットからでも入手できます。
 PROPQUEST_REQUESTBOX_INC_020012,You can get $QUEST_END_ITEM_NAME$ from any type of Yetti.,$QUEST_END_ITEM_NAME$は、どの種類のイエティからでも入手できます。
-PROPQUEST_REQUESTBOX_INC_020013,You can get $QUEST_END_ITEM_NAME$ from any type of Augu.,$QUEST_END_ITEM_NAME$ は、どの種類のアウグからでも入手できます。
-PROPQUEST_REQUESTBOX_INC_020014,You can get $QUEST_END_ITEM_NAME$ from any type of Ghost of the Forgotten.,$QUEST_END_ITEM_NAME$ は、どの種類のゴーストからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020013,You can get $QUEST_END_ITEM_NAME$ from any type of Augu.,$QUEST_END_ITEM_NAME$は、どの種類のアウグからでも入手できます。
+PROPQUEST_REQUESTBOX_INC_020014,You can get $QUEST_END_ITEM_NAME$ from any type of Ghost of the Forgotten.,$QUEST_END_ITEM_NAME$は、どの種類のゴーストからでも入手できます。
 PROPQUEST_REQUESTBOX_INC_020015,You can get $QUEST_END_ITEM_NAME$ from any type of Mammoth.,$QUEST_END_ITEM_NAME$は、どの種類のマンモスからでも入手できます。
 PROPQUEST_REQUESTBOX_INC_020016,You did it! Hooray! Here's your reward. Come back soon!,やったね！やったね！これはほんのお礼！また来てね！
 PROPQUEST_REQUESTBOX_INC_020017,More! More!,もっと！もっと！


### PR DESCRIPTION
### Description
- Added Japanese translations for quests in the Deadwallderness district that were previously unclear.
- Made minor overall corrections, such as fixing typos and standardizing terminology.

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project
