### PR TITLE
[Japanese] Fix Ultimate Jewel attach-count wording to match updated English source

### DIFF
--- a/Japanese/Items.csv
+++ b/Japanese/Items.csv
@@ -17093,16 +17093,16 @@ PROPITEM_TXT_800009,Shining Topaz (7),輝くトパーズ (7)
 PROPITEM_TXT_800010,Shining Topaz (8),輝くトパーズ (8)
 PROPITEM_TXT_800011,Shining Topaz (9),輝くトパーズ (9)
 PROPITEM_TXT_800012,Shining Topaz (10),輝くトパーズ (10)
-PROPITEM_TXT_800013,Gives +5 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+5を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800014,Gives +10 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+10を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800015,Gives +15 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+15を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800016,Gives +20 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+20を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800017,Gives +25 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+25を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800018,Gives +30 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+30を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800019,Gives +35 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+35を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800020,Gives +40 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+40を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800021,Gives +45 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+45を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800022,Gives +50 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+50を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800013,Gives +5 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+5を付与します。複数回装着可能です。
+PROPITEM_TXT_800014,Gives +10 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+10を付与します。複数回装着可能です。
+PROPITEM_TXT_800015,Gives +15 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+15を付与します。複数回装着可能です。
+PROPITEM_TXT_800016,Gives +20 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+20を付与します。複数回装着可能です。
+PROPITEM_TXT_800017,Gives +25 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+25を付与します。複数回装着可能です。
+PROPITEM_TXT_800018,Gives +30 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+30を付与します。複数回装着可能です。
+PROPITEM_TXT_800019,Gives +35 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+35を付与します。複数回装着可能です。
+PROPITEM_TXT_800020,Gives +40 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+40を付与します。複数回装着可能です。
+PROPITEM_TXT_800021,Gives +45 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+45を付与します。複数回装着可能です。
+PROPITEM_TXT_800022,Gives +50 Defense when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると防御力+50を付与します。複数回装着可能です。
 PROPITEM_TXT_800023,Shining Ruby (1),輝くルビー (1)
 PROPITEM_TXT_800024,Shining Ruby (2),輝くルビー (2)
 PROPITEM_TXT_800025,Shining Ruby (3),輝くルビー (3)
@@ -17113,16 +17113,16 @@ PROPITEM_TXT_800029,Shining Ruby (7),輝くルビー (7)
 PROPITEM_TXT_800030,Shining Ruby (8),輝くルビー (8)
 PROPITEM_TXT_800031,Shining Ruby (9),輝くルビー (9)
 PROPITEM_TXT_800032,Shining Ruby (10),輝くルビー (10)
-PROPITEM_TXT_800033,Gives +1 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+1を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800034,Gives +2 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+2を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800035,Gives +3 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+3を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800036,Gives +4 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+4を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800037,Gives +5 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+5を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800038,Gives +6 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+6を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800039,Gives +7 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+7を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800040,Gives +8 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+8を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800041,Gives +9 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+9を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800042,Gives +10 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+10を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800033,Gives +1 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+1を付与します。複数回装着可能です。
+PROPITEM_TXT_800034,Gives +2 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+2を付与します。複数回装着可能です。
+PROPITEM_TXT_800035,Gives +3 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+3を付与します。複数回装着可能です。
+PROPITEM_TXT_800036,Gives +4 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+4を付与します。複数回装着可能です。
+PROPITEM_TXT_800037,Gives +5 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+5を付与します。複数回装着可能です。
+PROPITEM_TXT_800038,Gives +6 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+6を付与します。複数回装着可能です。
+PROPITEM_TXT_800039,Gives +7 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+7を付与します。複数回装着可能です。
+PROPITEM_TXT_800040,Gives +8 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+8を付与します。複数回装着可能です。
+PROPITEM_TXT_800041,Gives +9 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+9を付与します。複数回装着可能です。
+PROPITEM_TXT_800042,Gives +10 Strength when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると力+10を付与します。複数回装着可能です。
 PROPITEM_TXT_800043,Shining Sapphire (1),輝くサファイア (1)
 PROPITEM_TXT_800044,Shining Sapphire (2),輝くサファイア (2)
 PROPITEM_TXT_800045,Shining Sapphire (3),輝くサファイア (3)
@@ -17133,16 +17133,16 @@ PROPITEM_TXT_800049,Shining Sapphire (7),輝くサファイア (7)
 PROPITEM_TXT_800050,Shining Sapphire (8),輝くサファイア (8)
 PROPITEM_TXT_800051,Shining Sapphire (9),輝くサファイア (9)
 PROPITEM_TXT_800052,Shining Sapphire (10),輝くサファイア (10)
-PROPITEM_TXT_800053,Gives +1 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+1を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800054,Gives +2 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+2を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800055,Gives +3 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+3を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800056,Gives +4 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+4を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800057,Gives +5 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+5を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800058,Gives +6 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+6を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800059,Gives +7 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+7を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800060,Gives +8 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+8を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800061,Gives +9 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+9を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800062,Gives +10 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+10を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800053,Gives +1 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+1を付与します。複数回装着可能です。
+PROPITEM_TXT_800054,Gives +2 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+2を付与します。複数回装着可能です。
+PROPITEM_TXT_800055,Gives +3 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+3を付与します。複数回装着可能です。
+PROPITEM_TXT_800056,Gives +4 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+4を付与します。複数回装着可能です。
+PROPITEM_TXT_800057,Gives +5 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+5を付与します。複数回装着可能です。
+PROPITEM_TXT_800058,Gives +6 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+6を付与します。複数回装着可能です。
+PROPITEM_TXT_800059,Gives +7 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+7を付与します。複数回装着可能です。
+PROPITEM_TXT_800060,Gives +8 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+8を付与します。複数回装着可能です。
+PROPITEM_TXT_800061,Gives +9 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+9を付与します。複数回装着可能です。
+PROPITEM_TXT_800062,Gives +10 Intelligence when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると知能+10を付与します。複数回装着可能です。
 PROPITEM_TXT_800063,Shining Emerald (1),輝くエメラルド (1)
 PROPITEM_TXT_800064,Shining Emerald (2),輝くエメラルド (2)
 PROPITEM_TXT_800065,Shining Emerald (3),輝くエメラルド (3)
@@ -17153,16 +17153,16 @@ PROPITEM_TXT_800069,Shining Emerald (7),輝くエメラルド (7)
 PROPITEM_TXT_800070,Shining Emerald (8),輝くエメラルド (8)
 PROPITEM_TXT_800071,Shining Emerald (9),輝くエメラルド (9)
 PROPITEM_TXT_800072,Shining Emerald (10),輝くエメラルド (10)
-PROPITEM_TXT_800073,Gives +1 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+1を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800074,Gives +2 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+2を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800075,Gives +3 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+3を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800076,Gives +4 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+4を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800077,Gives +5 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+5を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800078,Gives +6 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+6を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800079,Gives +7 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+7を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800080,Gives +8 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+8を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800081,Gives +9 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+9を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800082,Gives +10 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+10を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800073,Gives +1 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+1を付与します。複数回装着可能です。
+PROPITEM_TXT_800074,Gives +2 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+2を付与します。複数回装着可能です。
+PROPITEM_TXT_800075,Gives +3 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+3を付与します。複数回装着可能です。
+PROPITEM_TXT_800076,Gives +4 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+4を付与します。複数回装着可能です。
+PROPITEM_TXT_800077,Gives +5 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+5を付与します。複数回装着可能です。
+PROPITEM_TXT_800078,Gives +6 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+6を付与します。複数回装着可能です。
+PROPITEM_TXT_800079,Gives +7 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+7を付与します。複数回装着可能です。
+PROPITEM_TXT_800080,Gives +8 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+8を付与します。複数回装着可能です。
+PROPITEM_TXT_800081,Gives +9 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+9を付与します。複数回装着可能です。
+PROPITEM_TXT_800082,Gives +10 Dexterity when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると敏捷+10を付与します。複数回装着可能です。
 PROPITEM_TXT_800083,Shining Amethyst (1),輝くアメジスト (1)
 PROPITEM_TXT_800084,Shining Amethyst (2),輝くアメジスト (2)
 PROPITEM_TXT_800085,Shining Amethyst (3),輝くアメジスト (3)
@@ -17173,16 +17173,16 @@ PROPITEM_TXT_800089,Shining Amethyst (7),輝くアメジスト (7)
 PROPITEM_TXT_800090,Shining Amethyst (8),輝くアメジスト (8)
 PROPITEM_TXT_800091,Shining Amethyst (9),輝くアメジスト (9)
 PROPITEM_TXT_800092,Shining Amethyst (10),輝くアメジスト (10)
-PROPITEM_TXT_800093,Gives +1 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+1を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800094,Gives +2 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+2を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800095,Gives +3 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+3を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800096,Gives +4 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+4を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800097,Gives +5 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+5を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800098,Gives +6 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+6を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800099,Gives +7 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+7を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800100,Gives +8 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+8を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800101,Gives +9 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+9を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800102,Gives +10 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+10を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800093,Gives +1 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+1を付与します。複数回装着可能です。
+PROPITEM_TXT_800094,Gives +2 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+2を付与します。複数回装着可能です。
+PROPITEM_TXT_800095,Gives +3 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+3を付与します。複数回装着可能です。
+PROPITEM_TXT_800096,Gives +4 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+4を付与します。複数回装着可能です。
+PROPITEM_TXT_800097,Gives +5 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+5を付与します。複数回装着可能です。
+PROPITEM_TXT_800098,Gives +6 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+6を付与します。複数回装着可能です。
+PROPITEM_TXT_800099,Gives +7 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+7を付与します。複数回装着可能です。
+PROPITEM_TXT_800100,Gives +8 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+8を付与します。複数回装着可能です。
+PROPITEM_TXT_800101,Gives +9 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+9を付与します。複数回装着可能です。
+PROPITEM_TXT_800102,Gives +10 Stamina when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると体力+10を付与します。複数回装着可能です。
 PROPITEM_TXT_800103,Shining Diamond (1),輝くダイヤモンド (1)
 PROPITEM_TXT_800104,Shining Diamond (2),輝くダイヤモンド (2)
 PROPITEM_TXT_800105,Shining Diamond (3),輝くダイヤモンド (3)
@@ -17193,16 +17193,16 @@ PROPITEM_TXT_800109,Shining Diamond (7),輝くダイヤモンド (7)
 PROPITEM_TXT_800110,Shining Diamond (8),輝くダイヤモンド (8)
 PROPITEM_TXT_800111,Shining Diamond (9),輝くダイヤモンド (9)
 PROPITEM_TXT_800112,Shining Diamond (10),輝くダイヤモンド (10)
-PROPITEM_TXT_800113,Gives +50 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+50を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800114,Gives +100 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+100を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800115,Gives +150 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+150を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800116,Gives +200 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+200を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800117,Gives +250 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+250を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800118,Gives +300 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+300を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800119,Gives +350 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+350を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800120,Gives +400 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+400を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800121,Gives +450 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+450を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800122,Gives +500 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+500を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800113,Gives +50 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+50を付与します。複数回装着可能です。
+PROPITEM_TXT_800114,Gives +100 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+100を付与します。複数回装着可能です。
+PROPITEM_TXT_800115,Gives +150 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+150を付与します。複数回装着可能です。
+PROPITEM_TXT_800116,Gives +200 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+200を付与します。複数回装着可能です。
+PROPITEM_TXT_800117,Gives +250 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+250を付与します。複数回装着可能です。
+PROPITEM_TXT_800118,Gives +300 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+300を付与します。複数回装着可能です。
+PROPITEM_TXT_800119,Gives +350 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+350を付与します。複数回装着可能です。
+PROPITEM_TXT_800120,Gives +400 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+400を付与します。複数回装着可能です。
+PROPITEM_TXT_800121,Gives +450 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+450を付与します。複数回装着可能です。
+PROPITEM_TXT_800122,Gives +500 HP when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着するとHP+500を付与します。複数回装着可能です。
 PROPITEM_TXT_800123,Shining Onyx (1),輝くオニキス (1)
 PROPITEM_TXT_800124,Shining Onyx (2),輝くオニキス (2)
 PROPITEM_TXT_800125,Shining Onyx (3),輝くオニキス (3)
@@ -17213,16 +17213,16 @@ PROPITEM_TXT_800129,Shining Onyx (7),輝くオニキス (7)
 PROPITEM_TXT_800130,Shining Onyx (8),輝くオニキス (8)
 PROPITEM_TXT_800131,Shining Onyx (9),輝くオニキス (9)
 PROPITEM_TXT_800132,Shining Onyx (10),輝くオニキス (10)
-PROPITEM_TXT_800133,Gives +10 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+10を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800134,Gives +20 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+20を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800135,Gives +30 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+30を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800136,Gives +40 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+40を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800137,Gives +50 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+50を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800138,Gives +60 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+60を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800139,Gives +70 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+70を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800140,Gives +80 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+80を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800141,Gives +90 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+90を付与します。1回のみ装着可能です。
-PROPITEM_TXT_800142,Gives +100 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+100を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800133,Gives +10 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+10を付与します。複数回装着可能です。
+PROPITEM_TXT_800134,Gives +20 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+20を付与します。複数回装着可能です。
+PROPITEM_TXT_800135,Gives +30 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+30を付与します。複数回装着可能です。
+PROPITEM_TXT_800136,Gives +40 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+40を付与します。複数回装着可能です。
+PROPITEM_TXT_800137,Gives +50 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+50を付与します。複数回装着可能です。
+PROPITEM_TXT_800138,Gives +60 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+60を付与します。複数回装着可能です。
+PROPITEM_TXT_800139,Gives +70 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+70を付与します。複数回装着可能です。
+PROPITEM_TXT_800140,Gives +80 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+80を付与します。複数回装着可能です。
+PROPITEM_TXT_800141,Gives +90 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+90を付与します。複数回装着可能です。
+PROPITEM_TXT_800142,Gives +100 Attack Power when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると攻撃力+100を付与します。複数回装着可能です。
 PROPITEM_TXT_800143,Jewel Tweezers,ジュエルツイーザー
 PROPITEM_TXT_800144,You can get the attached jewel without destruction.,取り付けられたジュエルを破壊せずに回収できます。
 PROPITEM_TXT_800145,Rune of Increasing HP,HP増加のルーン
@@ -17280,25 +17280,25 @@ PROPITEM_TXT_800196,First-grade jewels and jewel pieces can be extracted from th
 PROPITEM_TXT_800197,Cutting Knife,カッティングナイフ
 PROPITEM_TXT_800198,Guarantees the success of extracting jewel pieces or first-grade jewels from a gemstone.,原石からジュエルの欠片または1級ジュエルを抽出する際の成功を保証します。
 PROPITEM_TXT_800199,Rainbow Jewel (1),レインボージュエル (1)
-PROPITEM_TXT_800200,Gives +1 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+1を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800200,Gives +1 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+1を付与します。複数回装着可能です。
 PROPITEM_TXT_800201,Rainbow Jewel (2),レインボージュエル (2)
-PROPITEM_TXT_800202,Gives +2 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+2を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800202,Gives +2 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+2を付与します。複数回装着可能です。
 PROPITEM_TXT_800203,Rainbow Jewel (3),レインボージュエル (3)
-PROPITEM_TXT_800204,Gives +3 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+3を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800204,Gives +3 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+3を付与します。複数回装着可能です。
 PROPITEM_TXT_800205,Rainbow Jewel (4),レインボージュエル (4)
-PROPITEM_TXT_800206,Gives +4 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+4を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800206,Gives +4 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+4を付与します。複数回装着可能です。
 PROPITEM_TXT_800207,Rainbow Jewel (5),レインボージュエル (5)
-PROPITEM_TXT_800208,Gives +5 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+5を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800208,Gives +5 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+5を付与します。複数回装着可能です。
 PROPITEM_TXT_800209,Rainbow Jewel (6),レインボージュエル (6)
-PROPITEM_TXT_800210,Gives +6 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+6を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800210,Gives +6 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+6を付与します。複数回装着可能です。
 PROPITEM_TXT_800211,Rainbow Jewel (7),レインボージュエル (7)
-PROPITEM_TXT_800212,Gives +7 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+7を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800212,Gives +7 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+7を付与します。複数回装着可能です。
 PROPITEM_TXT_800213,Rainbow Jewel (8),レインボージュエル (8)
-PROPITEM_TXT_800214,Gives +8 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+8を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800214,Gives +8 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+8を付与します。複数回装着可能です。
 PROPITEM_TXT_800215,Rainbow Jewel (9),レインボージュエル (9)
-PROPITEM_TXT_800216,Gives +9 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+9を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800216,Gives +9 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+9を付与します。複数回装着可能です。
 PROPITEM_TXT_800217,Rainbow Jewel (10),レインボージュエル (10)
-PROPITEM_TXT_800218,Gives +10 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+10を付与します。1回のみ装着可能です。
+PROPITEM_TXT_800218,Gives +10 All stat when applied to a ultimate weapon. Can only be attached once.,アルティマ武器に装着すると全ステータス+10を付与します。複数回装着可能です。
 PROPITEM_TXT_801000,Scroll of Pet Inventory (Character House),ペットインベントリの巻物(キャラクターハウス)
 PROPITEM_TXT_801001,Using this scroll will increase your maximum character house pet inventory slots by 1!,この巻物を使用すると、キャラクターハウスのペットインベントリの最大スロット数が1つ増加します！
 PROPITEM_TXT_801002,Scroll of Pet Inventory (Guild Ship),ペットインベントリの巻物(ギルド船)


### PR DESCRIPTION
### Description
\`English_Reference/Items.csv\` was recently corrected upstream: 80 Ultimate Jewel stat-bonus item descriptions (\`PROPITEM_TXT_800013\`–\`800218\`, covering Defense/STR/INT/DEX/STA/HP/Attack Power/All-stat grades) changed from "Can only be attached once." to "Can be attached multiple times." The Japanese translations still said 1回のみ装着可能です (once only), which now contradicts the source. Updated all 80 entries to 複数回装着可能です (multiple times) to match.

Keys still using the old English wording (\`PROPITEM_TXT_800162\`–\`800178\`, the percentage-stat variants) were left untouched since their source text has not been updated.

Files touched: \`Items.csv\` (Japanese only).

### 説明
\`English_Reference/Items.csv\`側で、アルティマジュエルのステータス付与系アイテム説明文80件（\`PROPITEM_TXT_800013\`〜\`800218\`、防御力/力/知能/敏捷/体力/HP/攻撃力/全ステータスの各グレード）の英語原文が「Can only be attached once.」（1回のみ装着可能）から「Can be attached multiple times.」（複数回装着可能）に修正されていました。日本語訳は「1回のみ装着可能です。」のままだったため、原文と矛盾していました。該当80件を「複数回装着可能です。」に修正しました。

同じ文言を含みますが英語原文がまだ「once」のままの他のキー（\`PROPITEM_TXT_800162\`〜\`800178\`、%系ステータス付与）は対象外とし、修正していません。

対象ファイル：\`Items.csv\`（日本語版のみ）

### Checklist
- [x] I confirm that all edited files are encoded in UTF-8
- [x] I did not add, delete, or reorder any translation entries
- [x] I only edited translation text (translation and/or correction of existing entries)
- [x] I did not modify keys, structure, or formatting
- [x] I have read and agree to the terms in **[CLA.md](https://github.com/Gala-Lab/Flyff-Universe-Translations/blob/master/CLA.md)** and understand that my contributions become the exclusive property of Gala Lab Corp. and may not be reused outside this project